### PR TITLE
add jupyter dependency to be able to open a notebook with poetry env …

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,10 @@ bitsandbytes = "0.42.0"
 lm-eval = "0.4.0"
 einops = "0.7.0"
 
+
+[tool.poetry.group.dev.dependencies]
+jupyter = "^1.0.0"
+
 [tool.poetry.scripts]
 flamingo = "flamingo.__main__:cli"
 


### PR DESCRIPTION
Add jupyter dependency to be able to run a jupyter notebook with a kernel using the poetry dependencies. 
Tested in a custom conda environment.

To run a jupyter notebook with the poetry dependencies:
`poetry run jupyter notebook`