### PR TITLE
Ci improvement part 2

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,7 +9,7 @@ on:
       - "**"
 
 jobs:
-  pytest_ruff:
+  ruff:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -25,7 +25,7 @@ jobs:
       - name: Lint with Ruff
         run: ruff --output-format=github .
         continue-on-error: false
-  tests:
+  unit-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This breaks out the jobs into three workers 
- Separate out ruff - now run in 9s!  - Will need to keep this in sync with the version defined in `pyproject.toml` 
- Separate out integration and unit tests

Questions/thoughts:
- Is there an easy way we could pull the ruff version from `pyproject.toml`?
- We could combine the integration tests and unit tests into one job for now, I'm good either way