### PR TITLE
Enabling Sphinx auto-build for docs and PR issues template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## What's changing
+
+## How to test it
+
+## Related Jira Ticket
+
+## Additional notes for reviewers

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,4 +1,5 @@
 name: Build and Deploy Documentation
+# FOLLOWING https://coderefinery.github.io/documentation/gh_workflow/
 
 on:
   push:
@@ -12,26 +13,39 @@ on:
 
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  docs:
+    build:
+      runs-on: ubuntu-latest
 
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.10"
-        cache: poetry
+      - name: Install poetry
+        run: pipx install poetry
 
-    - name: Build Documentation
-      run: |
-        cd docs
-        make html 
+      - name: Lock Poetry
+        run: poetry lock
 
-    - name: Deploy to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: docs/build/html
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: poetry
+
+      - name: Install docs dependencies
+        run: poetry install --only dev
+        continue-on-error: true
+
+      - name: Build Documentation
+        run: |
+          cd docs
+          make clean && make html 
+
+# TODO: ENABLE ONCE WE SET UP GITPAGES
+#      - name: Deploy to GitHub Pages
+#        uses: peaceiris/actions-gh-pages@v3
+#        with:
+#          github_token: ${{ secrets.GITHUB_TOKEN }}
+#          publish_dir: docs/build/html
+#          force_orphan: true

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,10 +3,11 @@ name: Documentation
 
 on:
   push:
-    branches:
-      - "main"
     paths:
       - 'docs/**'  # Trigger the workflow only when changes are made in the 'docs' directory
+    branches:
+      - 'main'
+
 
 
 jobs:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,37 @@
+name: Build and Deploy Documentation
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "**"
+    paths:
+      - 'docs/**'  # Trigger the workflow only when changes are made in the 'docs' directory
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+        cache: poetry
+
+    - name: Build Documentation
+      run: |
+        cd docs
+        make html 
+
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: docs/build/html

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,13 +1,10 @@
-name: Build and Deploy Documentation
+name: Documentation
 # FOLLOWING https://coderefinery.github.io/documentation/gh_workflow/
 
 on:
   push:
     branches:
       - "main"
-  pull_request:
-    branches:
-      - "**"
     paths:
       - 'docs/**'  # Trigger the workflow only when changes are made in the 'docs' directory
 
@@ -32,9 +29,8 @@ jobs:
         python-version: "3.10"
         cache: poetry
 
-    - name: Install docs dependencies
-      run: poetry install --only dev
-      continue-on-error: true
+    - name: Install docs dev dependencies
+      run: poetry install --with dev
 
     - name: Build Documentation
       run: |

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,18 +2,19 @@ name: Documentation
 # FOLLOWING https://coderefinery.github.io/documentation/gh_workflow/
 
 on:
+  # required to enable manual triggers on the GH web ui
   workflow_dispatch:
   pull_request:
     types: [closed] # Run conditionals based on opened/merged PRs
     paths:
-      - 'docs/*'  # Trigger the workflow only when changes are made in the 'docs' directory
+      - 'docs/**'  # Trigger the workflow only when changes are made in the 'docs' directory
     branches:
-      - 'main' # trigger publish only on closed PR in main
+      - 'docs' # trigger publish only on closed PR in docs
   push:
     paths:
       - 'docs/**'  # Trigger the workflow only when changes are made in the 'docs' directory
     branches:
-      - '**' # run doc build every time docs change in remote branch
+      - '**' # run doc build every time docs change in docs branch
 
 
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -14,33 +14,32 @@ on:
 
 jobs:
   docs:
-    build:
-      runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
 
-      steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
 
-      - name: Install poetry
-        run: pipx install poetry
+    - name: Install poetry
+      run: pipx install poetry
 
-      - name: Lock Poetry
-        run: poetry lock
+    - name: Lock Poetry
+      run: poetry lock
 
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-          cache: poetry
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+        cache: poetry
 
-      - name: Install docs dependencies
-        run: poetry install --only dev
-        continue-on-error: true
+    - name: Install docs dependencies
+      run: poetry install --only dev
+      continue-on-error: true
 
-      - name: Build Documentation
-        run: |
-          cd docs
-          make clean && make html 
+    - name: Build Documentation
+      run: |
+        cd docs
+        make clean && make html 
 
 # TODO: ENABLE ONCE WE SET UP GITPAGES
 #      - name: Deploy to GitHub Pages

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,13 +2,17 @@ name: Documentation
 # FOLLOWING https://coderefinery.github.io/documentation/gh_workflow/
 
 on:
+  pull_request:
+    types: [closed] # Run conditionals based on opened/merged PRs
+    paths:
+      - 'docs/*'  # Trigger the workflow only when changes are made in the 'docs' directory
+    branches:
+      - 'main' # trigger publish only on closed PR in main
   push:
     paths:
-      - 'docs/**'  # Trigger the workflow only when changes are made in the 'docs' directory
+      - 'docs/*'  # Trigger the workflow only when changes are made in the 'docs' directory
     branches:
-      - 'main'
-
-
+      - '**' # run doc build every time docs change in remote branch
 
 jobs:
   docs:
@@ -16,30 +20,37 @@ jobs:
 
     steps:
     - name: Checkout code
+      if: github.event_name == 'push'
       uses: actions/checkout@v4
 
     - name: Install poetry
+      if: github.event_name == 'push'
       run: pipx install poetry
 
     - name: Lock Poetry
+      if: github.event_name == 'push''
       run: poetry lock
 
     - name: Set up Python 3.10
+      if: github.event_name == 'push'
       uses: actions/setup-python@v5
       with:
         python-version: "3.10"
         cache: poetry
 
     - name: Install docs dev dependencies
+      if: github.event_name == 'push'
       run: poetry install --with dev
 
     - name: Build Documentation
+      if: github.event_name == 'push'
       run: |
         cd docs
-        make clean && make html 
+        make clean && make html
 
 # TODO: ENABLE ONCE WE SET UP GITPAGES
 #      - name: Deploy to GitHub Pages
+       # if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
 #        uses: peaceiris/actions-gh-pages@v3
 #        with:
 #          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,6 +2,7 @@ name: Documentation
 # FOLLOWING https://coderefinery.github.io/documentation/gh_workflow/
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [closed] # Run conditionals based on opened/merged PRs
     paths:
@@ -10,9 +11,11 @@ on:
       - 'main' # trigger publish only on closed PR in main
   push:
     paths:
-      - 'docs/*'  # Trigger the workflow only when changes are made in the 'docs' directory
+      - 'docs/**'  # Trigger the workflow only when changes are made in the 'docs' directory
     branches:
       - '**' # run doc build every time docs change in remote branch
+
+
 
 jobs:
   docs:
@@ -20,30 +23,30 @@ jobs:
 
     steps:
     - name: Checkout code
-      if: github.event_name == 'push'
+      if: ${{ github.event_name == 'push'}}
       uses: actions/checkout@v4
 
     - name: Install poetry
-      if: github.event_name == 'push'
+      if: ${{ github.event_name == 'push'}}
       run: pipx install poetry
 
     - name: Lock Poetry
-      if: github.event_name == 'push''
+      if: ${{ github.event_name == 'push'}}
       run: poetry lock
 
     - name: Set up Python 3.10
-      if: github.event_name == 'push'
+      if: ${{ github.event_name == 'push'}}
       uses: actions/setup-python@v5
       with:
         python-version: "3.10"
         cache: poetry
 
     - name: Install docs dev dependencies
-      if: github.event_name == 'push'
+      if: ${{ github.event_name == 'push'}}
       run: poetry install --with dev
 
     - name: Build Documentation
-      if: github.event_name == 'push'
+      if: ${{ github.event_name == 'push'}}
       run: |
         cd docs
         make clean && make html

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -14,7 +14,7 @@ on:
     paths:
       - 'docs/**'  # Trigger the workflow only when changes are made in the 'docs' directory
     branches:
-      - '**' # run doc build every time docs change in docs branch
+      - 'docs' # run doc build every time docs change in docs branch
 
 
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,15 +2,17 @@ name: Tests
 
 on:
   push:
+    paths-ignore:
+      - 'docs/**'
+      - '.github/**'
     branches:
       - 'main'
+  pull_request:
     paths-ignore:
       - 'docs/**'
-  pull_request:
+      - '.github/**'
     branches:
       - "**"
-    paths-ignore:
-      - 'docs/**'
 
 jobs:
   ruff:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,11 +6,13 @@ on:
       - "main"
     paths-ignore:
       - 'docs/**'
+      - 'workflows/**'
   pull_request:
     branches:
       - "**"
     paths-ignore:
       - 'docs/**'
+      - 'workflows/**'
 
 
 jobs:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -3,17 +3,14 @@ name: Tests
 on:
   push:
     branches:
-      - "main"
+      - 'main'
     paths-ignore:
       - 'docs/**'
-      - 'workflows/**'
   pull_request:
     branches:
       - "**"
     paths-ignore:
       - 'docs/**'
-      - 'workflows/**'
-
 
 jobs:
   ruff:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,17 +1,12 @@
 name: Tests
 
 on:
+  # required to enable manual triggers on the GH web ui
   workflow_dispatch:
   push:
-    paths-ignore:
-      - 'docs/*'
-      - '.github/*'
     branches:
       - 'main'
   pull_request:
-    paths-ignore:
-      - 'docs/*'
-      - '.github/*'
     branches:
       - "**"
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,9 +4,14 @@ on:
   push:
     branches:
       - "main"
+    paths-ignore:
+      - 'docs/**'
   pull_request:
     branches:
       - "**"
+    paths-ignore:
+      - 'docs/**'
+
 
 jobs:
   ruff:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,16 +1,17 @@
 name: Tests
 
 on:
+  workflow_dispatch:
   push:
     paths-ignore:
-      - 'docs/**'
-      - '.github/**'
+      - 'docs/*'
+      - '.github/*'
     branches:
       - 'main'
   pull_request:
     paths-ignore:
-      - 'docs/**'
-      - '.github/**'
+      - 'docs/*'
+      - '.github/*'
     branches:
       - "**"
 

--- a/README.md
+++ b/README.md
@@ -86,3 +86,4 @@ See the `examples/` folder for more examples of submitting Ray jobs.
 
 See the [contributing](CONTRIBUTING.md) guide for more information on development workflows 
 and/or building locally.
+# test_workflow

--- a/README.md
+++ b/README.md
@@ -86,4 +86,4 @@ See the `examples/` folder for more examples of submitting Ray jobs.
 
 See the [contributing](CONTRIBUTING.md) guide for more information on development workflows 
 and/or building locally.
-# test_workflow
+

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,6 +15,7 @@ author = "Sean Friedowitz, Vicki Boykis, Aaron Gonzales"
 extensions = [
     "nbsphinx",
     "myst_parser",
+    "sphinx_codeautolink",
 ]
 
 # use language set by highlight directive if no language is set by role
@@ -22,6 +23,9 @@ inline_highlight_respect_highlight = False
 
 # use language set by highlight directive if no role is set
 inline_highlight_literals = False
+
+# Set deeplinks
+myst_heading_anchors = 3
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
@@ -32,4 +36,4 @@ source_suffix = [".rst", ".md"]
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = "furo"
-html_static_path = ["_static"]
+html_static_path = []

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -33,7 +33,7 @@ Evaluation
    evaluation_concepts
 
 Examples
-----------
+-----------
 .. toctree::
    :maxdepth: 3
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ Sphinx = "7.2.6"
 nbsphinx = "0.9.3"
 myst-parser = "2.0.0"
 recommonmark = "^0.7.1"
+furo = "2024.1.29"
+sphinx-codeautolink = "0.15.0"
 
 [tool.poetry.group.finetuning.dependencies]
 datasets = "2.16.1"


### PR DESCRIPTION
Couple of changes here: 

1. GitHub actions for only docs builds on changes to the docs repo
2. A step that deploys to GH pages once we have the build setup [See here for reference. ](https://coderefinery.github.io/documentation/gh_workflow/)
3. lightweight PR template once we start working on issues publicly
