### PR TITLE
Updated github workflows to do manual triggers from web UI for both test and prod

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,6 +11,8 @@ on:
 jobs:
   ruff:
     runs-on: ubuntu-latest
+    env:
+     VENV_PATH: "$HOME/venv" 
     steps:
       - uses: actions/checkout@v4
 
@@ -29,17 +31,21 @@ jobs:
         env:
           RUFF_VERSION: ${{ steps.get_ruff_version.outputs.result }}
         run: |
-          export VENV_PATH="$HOME/venv" 
           python3 -m venv $VENV_PATH 
           source "$VENV_PATH/bin/activate"
           pip install uv
           uv pip install ruff
-          ruff --output-format=github .
         continue-on-error: false
+      - name: run ruff
+        run: | 
+          source "$VENV_PATH/bin/activate"
+          ruff --output-format=github .
         
 
   unit-tests:
     runs-on: ubuntu-latest
+    env:
+     VENV_PATH: "$HOME/venv" 
     steps:
       - uses: actions/checkout@v4
 
@@ -47,12 +53,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-          cache: poetry
 
-      - name: set up poetry
+      - name: Install Poetry
         id: poetry
         run: |
-          export VENV_PATH="$HOME/venv" 
           python3 -m venv $VENV_PATH 
           source "$VENV_PATH/bin/activate"
           pip install uv
@@ -78,6 +82,8 @@ jobs:
 
   integration-tests:
     runs-on: ubuntu-latest
+    env:
+     VENV_PATH: "$HOME/venv" 
     steps:
       - uses: actions/checkout@v4
 
@@ -85,11 +91,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-          cache: poetry
 
       - name: Install poetry
+        id: poetry
         run: |
-          export VENV_PATH="$HOME/venv" 
           python3 -m venv $VENV_PATH 
           source "$VENV_PATH/bin/activate"
           pip install uv
@@ -97,6 +102,9 @@ jobs:
         continue-on-error: false
 
       - name: Lock Poetry
+        run: |
+          source "$VENV_PATH/bin/activate"
+          poetry lock
         run: |
           source "$VENV_PATH/bin/activate"
           poetry lock

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,7 +29,7 @@ jobs:
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
           uv venv
-          echo "VIRTUAL_ENV={$HOME/.venv}" >> $GITHUB_ENV
+          echo "VIRTUAL_ENV=$HOME/.venv" >> $GITHUB_ENV
 
       - name: install ruff
         env:
@@ -58,7 +58,7 @@ jobs:
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
           uv venv
-          echo "VIRTUAL_ENV={$HOME/.venv}" >> $GITHUB_ENV
+          echo "VIRTUAL_ENV=$HOME/.venv" >> $GITHUB_ENV
 
       - name: Install Poetry
         id: poetry
@@ -98,7 +98,7 @@ jobs:
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
           uv venv
-          echo "VIRTUAL_ENV={$HOME/.venv}" >> $GITHUB_ENV
+          echo "VIRTUAL_ENV=$HOME/.venv" >> $GITHUB_ENV
 
       - name: Install poetry
         id: poetry

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,12 +19,22 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install Ruff
-        run: pipx install ruff==0.2.1 # Needs to match pyproject.toml
+      - name: get ruff version
+        id: get_ruff_version
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq -oy '.tool.poetry.dev-dependencies.ruff' pyproject.toml
 
-      - name: Lint with Ruff
+      - name: install ruff
+        env:
+          RUFF_VERSION: ${{ steps.get_ruff_version.outputs.result }}
+        run: pipx install ruff=="$RUFF_VERSION"
+        continue-on-error: false
+
+      - name: run ruff
         run: ruff --output-format=github .
         continue-on-error: false
+
   unit-tests:
     runs-on: ubuntu-latest
     steps:
@@ -50,6 +60,7 @@ jobs:
         run: |
           poetry run pytest tests/unit
         continue-on-error: false
+
   integration-tests:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Install UV, venv
         run: |
           python3 -m venv "$HOME/venv" 
-          source "$VENV_PATH/bin/activate"
+          source "$HOME/venv/bin/activate"
           pip install uv
           echo "PATH=$PATH" >> $GITHUB_ENV
 
@@ -58,7 +58,7 @@ jobs:
       - name: Install UV, venv
         run: |
           python3 -m venv "$HOME/venv" 
-          source "$VENV_PATH/bin/activate"
+          source "$HOME/venv/bin/activate"
           pip install uv
           echo "PATH=$PATH" >> $GITHUB_ENV
 
@@ -95,7 +95,7 @@ jobs:
       - name: Install UV, venv
         run: |
           python3 -m venv "$HOME/venv" 
-          source "$VENV_PATH/bin/activate"
+          source "$HOME/venv/bin/activate"
           pip install uv
           echo "PATH=$PATH" >> $GITHUB_ENV
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -35,11 +35,13 @@ jobs:
         env:
           RUFF_VERSION: ${{ steps.get_ruff_version.outputs.result }}
         run: |
+          . .venv/bin/activate
           uv pip install ruff
         continue-on-error: false
 
       - name: run ruff
         run: | 
+          . .venv/bin/activate
           ruff --output-format=github .
         continue-on-error: false
         
@@ -103,19 +105,23 @@ jobs:
       - name: Install poetry
         id: poetry
         run: |
+          . .venv/bin/activate
           uv pip install poetry 
         continue-on-error: false
 
       - name: Lock Poetry
         run: |
+          . .venv/bin/activate
           poetry lock
 
       - name: Install test dependencies
         run: |
+          . .venv/bin/activate
           poetry install
         continue-on-error: true
 
       - name: Run integration tests
         run: |
+          . .venv/bin/activate
           poetry run pytest tests/integration
         continue-on-error: false

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,10 +27,9 @@ jobs:
 
       - name: Install UV, venv
         run: |
-          python3 -m venv "$HOME/venv" 
-          source "$HOME/venv/bin/activate"
-          pip install uv
-          echo "PATH=$PATH" >> $GITHUB_ENV
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          uv venv
+          echo "VIRTUAL_ENV={$HOME/.venv}" >> $GITHUB_ENV
 
       - name: install ruff
         env:
@@ -57,28 +56,31 @@ jobs:
 
       - name: Install UV, venv
         run: |
-          python3 -m venv "$HOME/venv" 
-          source "$HOME/venv/bin/activate"
-          pip install uv
-          echo "PATH=$PATH" >> $GITHUB_ENV
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          uv venv
+          echo "VIRTUAL_ENV={$HOME/.venv}" >> $GITHUB_ENV
 
       - name: Install Poetry
         id: poetry
         run: |
+          . .venv/bin/activate
           uv pip install poetry
         continue-on-error: false
 
       - name: Lock Poetry
         run: |
+          . .venv/bin/activate
           poetry lock
 
       - name: Install test dependencies
         run: |
+          . .venv/bin/activate
           poetry install
         continue-on-error: true
 
       - name: Run unit tests
         run: |
+          . .venv/bin/activate
           poetry run pytest tests/unit
         continue-on-error: false
 
@@ -94,11 +96,9 @@ jobs:
 
       - name: Install UV, venv
         run: |
-          python3 -m venv "$HOME/venv" 
-          source "$HOME/venv/bin/activate"
-          pip install uv
-          echo "PATH=$PATH" >> $GITHUB_ENV
-
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          uv venv
+          echo "VIRTUAL_ENV={$HOME/.venv}" >> $GITHUB_ENV
 
       - name: Install poetry
         id: poetry

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,7 +31,7 @@ jobs:
         run: pipx install ruff=="$RUFF_VERSION"
         continue-on-error: false
 
-      - name: run ruff
+      - name: Lint with Ruff
         run: ruff --output-format=github .
         continue-on-error: false
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -32,6 +32,7 @@ jobs:
           export VENV_PATH="$HOME/venv" 
           python3 -m venv $VENV_PATH 
           source "$VENV_PATH/bin/activate"
+          pip install uv
           uv pip install ruff
           ruff --output-format=github .
         continue-on-error: false
@@ -59,14 +60,19 @@ jobs:
         continue-on-error: false
 
       - name: Lock Poetry
-        run: poetry lock
+        run: |
+          source "$VENV_PATH/bin/activate"
+          poetry lock
 
       - name: Install test dependencies
-        run: poetry install
+        run: |
+          source "$VENV_PATH/bin/activate"
+          poetry install
         continue-on-error: true
 
       - name: Run unit tests
         run: |
+          source "$VENV_PATH/bin/activate"
           poetry run pytest tests/unit
         continue-on-error: false
 
@@ -74,6 +80,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: poetry
 
       - name: Install poetry
         run: |
@@ -85,19 +97,18 @@ jobs:
         continue-on-error: false
 
       - name: Lock Poetry
-        run: poetry lock
-
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-          cache: poetry
+        run: |
+          source "$VENV_PATH/bin/activate"
+          poetry lock
 
       - name: Install test dependencies
-        run: poetry install
+        run: |
+          source "$VENV_PATH/bin/activate"
+          poetry install
         continue-on-error: true
 
       - name: Run integration tests
         run: |
+          source "$VENV_PATH/bin/activate"
           poetry run pytest tests/integration
         continue-on-error: false

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -105,9 +105,6 @@ jobs:
         run: |
           source "$VENV_PATH/bin/activate"
           poetry lock
-        run: |
-          source "$VENV_PATH/bin/activate"
-          poetry lock
 
       - name: Install test dependencies
         run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,32 +25,41 @@ jobs:
         with:
           cmd: yq -oy '.tool.poetry.dev-dependencies.ruff' pyproject.toml
 
-      - name: install ruff
+      - name: install and run ruff
         env:
           RUFF_VERSION: ${{ steps.get_ruff_version.outputs.result }}
-        run: pipx install ruff=="$RUFF_VERSION"
+        run: |
+          export VENV_PATH="$HOME/venv" 
+          python3 -m venv $VENV_PATH 
+          source "$VENV_PATH/bin/activate"
+          uv pip install ruff
+          ruff --output-format=github .
         continue-on-error: false
-
-      - name: Lint with Ruff
-        run: ruff --output-format=github .
-        continue-on-error: false
+        
 
   unit-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install poetry
-        run: pipx install poetry
-
-      - name: Lock Poetry
-        run: poetry lock
-
       - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
           cache: poetry
+
+      - name: set up poetry
+        id: poetry
+        run: |
+          export VENV_PATH="$HOME/venv" 
+          python3 -m venv $VENV_PATH 
+          source "$VENV_PATH/bin/activate"
+          pip install uv
+          uv pip install ruff poetry
+        continue-on-error: false
+
+      - name: Lock Poetry
+        run: poetry lock
 
       - name: Install test dependencies
         run: poetry install
@@ -67,7 +76,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install poetry
-        run: pipx install poetry
+        run: |
+          export VENV_PATH="$HOME/venv" 
+          python3 -m venv $VENV_PATH 
+          source "$VENV_PATH/bin/activate"
+          pip install uv
+          uv pip install poetry 
+        continue-on-error: false
 
       - name: Lock Poetry
         run: poetry lock

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,8 +11,6 @@ on:
 jobs:
   ruff:
     runs-on: ubuntu-latest
-    env:
-     VENV_PATH: "$HOME/venv" 
     steps:
       - uses: actions/checkout@v4
 
@@ -27,25 +25,28 @@ jobs:
         with:
           cmd: yq -oy '.tool.poetry.dev-dependencies.ruff' pyproject.toml
 
-      - name: install and run ruff
+      - name: Install UV, venv
+        run: |
+          python3 -m venv "$HOME/venv" 
+          source "$VENV_PATH/bin/activate"
+          pip install uv
+          echo "PATH=$PATH" >> $GITHUB_ENV
+
+      - name: install ruff
         env:
           RUFF_VERSION: ${{ steps.get_ruff_version.outputs.result }}
         run: |
-          python3 -m venv $VENV_PATH 
-          source "$VENV_PATH/bin/activate"
-          pip install uv
           uv pip install ruff
         continue-on-error: false
+
       - name: run ruff
         run: | 
-          source "$VENV_PATH/bin/activate"
           ruff --output-format=github .
+        continue-on-error: false
         
 
   unit-tests:
     runs-on: ubuntu-latest
-    env:
-     VENV_PATH: "$HOME/venv" 
     steps:
       - uses: actions/checkout@v4
 
@@ -54,36 +55,35 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Install UV, venv
+        run: |
+          python3 -m venv "$HOME/venv" 
+          source "$VENV_PATH/bin/activate"
+          pip install uv
+          echo "PATH=$PATH" >> $GITHUB_ENV
+
       - name: Install Poetry
         id: poetry
         run: |
-          python3 -m venv $VENV_PATH 
-          source "$VENV_PATH/bin/activate"
-          pip install uv
-          uv pip install ruff poetry
+          uv pip install poetry
         continue-on-error: false
 
       - name: Lock Poetry
         run: |
-          source "$VENV_PATH/bin/activate"
           poetry lock
 
       - name: Install test dependencies
         run: |
-          source "$VENV_PATH/bin/activate"
           poetry install
         continue-on-error: true
 
       - name: Run unit tests
         run: |
-          source "$VENV_PATH/bin/activate"
           poetry run pytest tests/unit
         continue-on-error: false
 
   integration-tests:
     runs-on: ubuntu-latest
-    env:
-     VENV_PATH: "$HOME/venv" 
     steps:
       - uses: actions/checkout@v4
 
@@ -92,28 +92,30 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Install UV, venv
+        run: |
+          python3 -m venv "$HOME/venv" 
+          source "$VENV_PATH/bin/activate"
+          pip install uv
+          echo "PATH=$PATH" >> $GITHUB_ENV
+
+
       - name: Install poetry
         id: poetry
         run: |
-          python3 -m venv $VENV_PATH 
-          source "$VENV_PATH/bin/activate"
-          pip install uv
           uv pip install poetry 
         continue-on-error: false
 
       - name: Lock Poetry
         run: |
-          source "$VENV_PATH/bin/activate"
           poetry lock
 
       - name: Install test dependencies
         run: |
-          source "$VENV_PATH/bin/activate"
           poetry install
         continue-on-error: true
 
       - name: Run integration tests
         run: |
-          source "$VENV_PATH/bin/activate"
           poetry run pytest tests/integration
         continue-on-error: false

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,8 +29,8 @@ jobs:
           export VENV_PATH="$HOME/venv" 
           python3 -m venv $VENV_PATH 
           source "$VENV_PATH/bin/activate"
-          pip install -U pip setuptools
-          pip install poetry
+          pip install uv
+          uv pip install pip setuptools poetry
           poetry config repositories.testpypi https://test.pypi.org/legacy/
           poetry build
         continue-on-error: false

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,4 +1,4 @@
-# Build and publish to PyPI
+name: Build and publish to PyPI
 
 on: 
   workflow_dispatch:
@@ -7,13 +7,8 @@ on:
           type: choice
           description: Prod or Test
           options: 
-          - prod
           - test
-        message:
-          required: true
-        environment:
-          type: environment
-
+          - prod
 
 jobs:
     build_dist:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,21 +1,24 @@
 # Build and publish to PyPI
 
 on: 
-  push:
-    tags:
-      - "v*"
-  pull_request:
-    types:
-        - labeled
-    branches:
-        - main
   workflow_dispatch:
+    inputs:
+        prod_or_test:
+          type: choice
+          description: Prod or Test
+          options: 
+          - prod
+          - test
+        message:
+          required: true
+        environment:
+          type: environment
+
 
 jobs:
     build_dist:
       name: Build distribution 📦
       runs-on: ubuntu-latest
-      if: ${{ github.event.label.name == 'release' }}
       steps:
       - uses: actions/checkout@v4
       - name: set up python
@@ -23,15 +26,25 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: set up poetry
+      - name: Install UV, venv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          uv venv
+          echo "VIRTUAL_ENV=$HOME/.venv" >> $GITHUB_ENV
+
+      - name: Install poetry
         id: setup
         run: |
-          export VENV_PATH="$HOME/venv" 
-          python3 -m venv $VENV_PATH 
-          source "$VENV_PATH/bin/activate"
-          pip install uv
-          uv pip install pip setuptools poetry
+          . .venv/bin/activate
+          uv pip install poetry 
           poetry config repositories.testpypi https://test.pypi.org/legacy/
+          poetry build
+        continue-on-error: false
+
+      - name: Build package
+        id: build_package
+        run: |
+          . .venv/bin/activate
           poetry build
         continue-on-error: false
 
@@ -44,11 +57,11 @@ jobs:
           retention-days: 1
 
       - name: Publish dist to test pypi
+        if: ${{ inputs.prod_or_test == 'test' }}
         env:
             POETRY_PYPI_TOKEN_TESTPYPI: ${{ secrets.PYPI_TEST_KEY }}
         run: |
-            source "$HOME/venv/bin/activate"
-            cd $GITHUB_WORKSPACE
+            . .venv/bin/activate
             poetry publish --repository testpypi
         continue-on-error: false
 
@@ -57,7 +70,7 @@ jobs:
             POETRY_PYPI_TOKEN: ${{ secrets.PYPI_KEY }}
         # only runs full release if we're on main
         # tag filter and label filter were already hit
-        if: endsWith(github.event.base_ref, 'main') == true
+        if: ${{ inputs.prod_or_test == 'prod' }}
         run: |
             source "$HOME/venv/bin/activate"
             poetry publish 
@@ -81,6 +94,7 @@ jobs:
 
         - name: Release Draft
           uses: softprops/action-gh-release@v1
+          if: ${{ inputs.prod_or_test == 'test' }}
           with:
              files: ./dist/*
              draft: true
@@ -88,6 +102,6 @@ jobs:
         - name: Release
           uses: softprops/action-gh-release@v1
           # only runs full release if we're on main; tag filter already hit above
-          if: endsWith(github.event.base_ref, 'main') == true
+          if: ${{ inputs.prod_or_test == 'prod' }}
           with:
              files: ./dist/*

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,14 +5,17 @@ on:
     tags:
       - "v*"
   pull_request:
+    types:
+        - labeled
     branches:
-      - "main"
+        - main
   workflow_dispatch:
 
 jobs:
     build_dist:
       name: Build distribution 📦
       runs-on: ubuntu-latest
+      if: ${{ github.event.label.name == 'release' }}
       steps:
       - uses: actions/checkout@v4
       - name: set up python
@@ -30,6 +33,7 @@ jobs:
           pip install poetry
           poetry config repositories.testpypi https://test.pypi.org/legacy/
           poetry build
+        continue-on-error: false
 
       - name: Archive Production Artifact
         uses: actions/upload-artifact@v4
@@ -42,19 +46,17 @@ jobs:
       - name: Publish dist to test pypi
         env:
             POETRY_PYPI_TOKEN_TESTPYPI: ${{ secrets.PYPI_TEST_KEY }}
-            
-        if: ${{ github.event_name == 'pull_request' }}
         run: |
             source "$HOME/venv/bin/activate"
             cd $GITHUB_WORKSPACE
-            echo "$GITHUB_WORKSPACE"
-            which poetry
             poetry publish --repository testpypi
-            
+        continue-on-error: false
+
       - name: Publish dist to real pypi
         env:
             POETRY_PYPI_TOKEN: ${{ secrets.PYPI_KEY }}
-        # only runs full release if we're on main; tag filter already hit above
+        # only runs full release if we're on main
+        # tag filter and label filter were already hit
         if: endsWith(github.event.base_ref, 'main') == true
         run: |
             source "$HOME/venv/bin/activate"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,36 +121,7 @@ poetry publish --build
 
 `.github/workflows/publish.yaml' contains the GitHub Action used to do releases and push wheels to PyPI.
 
-There are two subcases - draft/dev and the 'real' release.
 
+You can trigger a publish workflow via [LM Buddy Actions](https://github.com/mozilla-ai/lm-buddy/actions). Choose `test` or `prod` from the dropdown menu. 
 
-### Draft / Test releases
-
-If a contributed opens a PR with a git version tag (e.g., `vX.Y.Z`) , the draft process will start which does the following:
-
-- upload a version to test PyPI 
-- make a draft release on github.
-
-
-this is to ensure the full process works before merging to main.
-
-
-### Real release
-
-If a commit is made to `main` with a git version tag (e.g., `vX.Y.Z`) and is coming from a PR labeled `release`, the full process will run. The workflow should look like:
-
-- make your changes that will be included in a release 
-- update the version in `pyproject.toml`
-- add an annotated tag, e.g.:
-  * `git tag -a v1.4.0 -m "1.4.0 prepped for release; see ___ for changes"` or
-  * `git tag -a v1.4.3 -m "1.4.3 is a patch for issue ____"`
-- push your changes to upstream 
-- open a PR to main with label "release"
-- verify that the project builds
-- land PR
-
-
-
-
-
-
+Most often failures will involve forgetting to bump the version in `pyproject.toml`, which will trigger PyPI (both test and prod) to reject the package.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,7 @@ There are two subcases - draft/dev and the 'real' release.
 
 ### Draft / Test releases
 
-If a contributed opens a PR to `main` with a git version tag (e.g., `vX.Y.Z`) , the draft process will start which does the following:
+If a contributed opens a PR with a git version tag (e.g., `vX.Y.Z`) , the draft process will start which does the following:
 
 - upload a version to test PyPI 
 - make a draft release on github.
@@ -137,18 +137,15 @@ this is to ensure the full process works before merging to main.
 
 ### Real release
 
-If a commit is made to `main` with a git version tag (e.g., `vX.Y.Z`), the full process will run, and upload the package to PyPI and make a formal Release. 
+If a commit is made to `main` with a git version tag (e.g., `vX.Y.Z`) and is coming from a PR labeled `release`, the full process will run. The workflow should look like:
 
-
-The workflow should look like the following:
-
-- make your changes that will be included in a release (could be a long running dev branch or otherwise)
+- make your changes that will be included in a release 
 - update the version in `pyproject.toml`
 - add an annotated tag, e.g.:
   * `git tag -a v1.4.0 -m "1.4.0 prepped for release; see ___ for changes"` or
   * `git tag -a v1.4.3 -m "1.4.3 is a patch for issue ____"`
 - push your changes to upstream 
-- open a PR to main
+- open a PR to main with label "release"
 - verify that the project builds
 - land PR
 


### PR DESCRIPTION
* Changed to trigger releases manually on the github web UI
*  parses Ruff's version directly
* uses UV as a python package installer 