### PR TITLE
Adding Actions workflow to build Sphinx docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,3 +5,4 @@
 ## Related Jira Ticket
 
 ## Additional notes for reviewers
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## What's changing
+
+## How to test it
+
+## Related Jira Ticket
+
+## Additional notes for reviewers

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -29,7 +29,6 @@ jobs:
       with:
         python-version: "3.10"
 
-    #install sphinx dependencies directly due to this poetry issue https://github.com/sphinx-doc/sphinx/issues/11218
     - name: Build Documentation
       run: |
         cd docs

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,57 @@
+name: Build and Publish Docs
+
+on:
+  # required to enable manual triggers on the GH web ui
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - "**"
+  # separate workflow that runs on PRs to main
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+
+    #install sphinx dependencies directly due to this poetry issue https://github.com/sphinx-doc/sphinx/issues/11218
+    - name: Build Documentation
+      run: |
+        cd docs
+        pip install uv
+        uv venv
+        source .venv/bin/activate
+        uv pip install sphinx nbsphinx myst-parser furo sphinx_codeautolink
+        sphinx-build source build/html
+
+    - name: Setup Pages
+      uses: actions/configure-pages@v4
+
+    - name: Upload Artifact
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: docs/build/html/
+
+    - name: Deploy
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      uses: actions/deploy-pages@v4
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: docs/build/html
+

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,6 +15,7 @@ author = "Sean Friedowitz, Vicki Boykis, Aaron Gonzales"
 extensions = [
     "nbsphinx",
     "myst_parser",
+    "sphinx_codeautolink",
 ]
 
 # use language set by highlight directive if no language is set by role
@@ -32,4 +33,4 @@ source_suffix = [".rst", ".md"]
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = "furo"
-html_static_path = ["_static"]
+html_static_path = []


### PR DESCRIPTION
## What's changing
[Closing this PR](https://github.com/mozilla-ai/lm-buddy/pull/44) in favor of a new cleaner workflow rebased off latest `main`. This PR adds a workflow for building docs and rebuilding the documentation site on merge into `main`.  It runs on every opened branch as a separate workflow and takes ~`30` seconds to build/deploy. 

## How to test it

Check the `yaml` config trigger a manual run. 

## Related Jira Ticket

## Additional notes for reviewers
