### PR TITLE
Fix up epoch vs epochs in config

### DIFF
--- a/examples/configs/finetuning/finetuning_config.yaml
+++ b/examples/configs/finetuning/finetuning_config.yaml
@@ -25,7 +25,7 @@ trainer:
   learning_rate: 0.001
   num_train_epochs: 2
   save_steps: 1
-  save_strategy: "epochs"
+  save_strategy: "epoch"
   logging_steps: 1
   logging_strategy: "steps"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lm-buddy"
-version = "0.2.3"
+version = "0.2.4"
 authors = [
     { name = "Sean Friedowitz", email = "sean@mozilla.ai" },
     { name = "Aaron Gonzales", email = "aaron@mozilla.ai" },


### PR DESCRIPTION
Noticed `epochs` was an invalid value when running training.
