### PR TITLE
Pinning lm-harness at the git hash

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -33,7 +33,6 @@ jobs:
     - name: Set up Environment
       id: setup
       run: |
-        curl -LsSf https://astral.sh/uv/install.sh | sh
         python3 -m venv .venv
         echo "VIRTUAL_ENV=$HOME/.venv" >> $GITHUB_ENV
       continue-on-error: false
@@ -42,7 +41,7 @@ jobs:
       id: install_build_dependencies
       run: |
         . .venv/bin/activate
-        pip install "lm-buddy[docs] @ ."
+        pip install ".[docs]"
       continue-on-error: false 
 
     - name: Build Documentation

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -42,7 +42,7 @@ jobs:
       id: install_build_dependencies
       run: |
         . .venv/bin/activate
-        uv pip install "lm-buddy[docs] @ ."
+        pip install "lm-buddy[docs] @ ."
       continue-on-error: false 
 
     - name: Build Documentation

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -34,7 +34,7 @@ jobs:
       id: setup
       run: |
         curl -LsSf https://astral.sh/uv/install.sh | sh
-        python3 -m venv
+        python3 -m venv .venv
         echo "VIRTUAL_ENV=$HOME/.venv" >> $GITHUB_ENV
       continue-on-error: false
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -34,7 +34,7 @@ jobs:
       id: setup
       run: |
         curl -LsSf https://astral.sh/uv/install.sh | sh
-        uv venv
+        python3 -m venv
         echo "VIRTUAL_ENV=$HOME/.venv" >> $GITHUB_ENV
       continue-on-error: false
 

--- a/.github/workflows/merge_checks.yaml
+++ b/.github/workflows/merge_checks.yaml
@@ -58,7 +58,7 @@ jobs:
         id: setup
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
-          uv venv
+          python3 -m venv
           echo "VIRTUAL_ENV=$HOME/.venv" >> $GITHUB_ENV
         continue-on-error: false
 
@@ -66,7 +66,7 @@ jobs:
         id: install_package
         run: |
           . .venv/bin/activate
-          uv pip install "lm_buddy[dev] @ ."
+          pip install "lm_buddy[dev] @ ."
         continue-on-error: false
 
       - name: Unit Tests

--- a/.github/workflows/merge_checks.yaml
+++ b/.github/workflows/merge_checks.yaml
@@ -34,7 +34,7 @@ jobs:
           . .venv/bin/activate
           uv pip install toml-cli
           uv pip install $(toml get --toml-path pyproject.toml "project.optional-dependencies.ruff[0]")
-          uv pip install lm-eval[wandb, openai]@git+https://github.com/EleutherAI/lm-evaluation-harness.git@45823914a3e445076a1ba12c9b1501c98e3dd20d
+          uv pip install lm-eval @ git+https://github.com/EleutherAI/lm-evaluation-harness.git@45823914a3e445076a1ba12c9b1501c98e3dd20d
         continue-on-error: false
           
       - name: Linting with Ruff

--- a/.github/workflows/merge_checks.yaml
+++ b/.github/workflows/merge_checks.yaml
@@ -32,8 +32,8 @@ jobs:
         id: install_dependencies
         run: |
           . .venv/bin/activate
-          uv pip install toml-cli
-          uv pip install $(toml get --toml-path pyproject.toml "project.optional-dependencies.ruff[0]")
+          pip install toml-cli
+          pip install $(toml get --toml-path pyproject.toml "project.optional-dependencies.ruff[0]")
         continue-on-error: false
           
       - name: Linting with Ruff

--- a/.github/workflows/merge_checks.yaml
+++ b/.github/workflows/merge_checks.yaml
@@ -34,7 +34,6 @@ jobs:
           . .venv/bin/activate
           uv pip install toml-cli
           uv pip install $(toml get --toml-path pyproject.toml "project.optional-dependencies.ruff[0]")
-          uv pip install lm-eval @ git+https://github.com/EleutherAI/lm-evaluation-harness.git@45823914a3e445076a1ba12c9b1501c98e3dd20d
         continue-on-error: false
           
       - name: Linting with Ruff

--- a/.github/workflows/merge_checks.yaml
+++ b/.github/workflows/merge_checks.yaml
@@ -58,7 +58,7 @@ jobs:
         id: setup
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
-          python3 -m venv
+          python3 -m venv .venv
           echo "VIRTUAL_ENV=$HOME/.venv" >> $GITHUB_ENV
         continue-on-error: false
 

--- a/.github/workflows/merge_checks.yaml
+++ b/.github/workflows/merge_checks.yaml
@@ -34,6 +34,7 @@ jobs:
           . .venv/bin/activate
           uv pip install toml-cli
           uv pip install $(toml get --toml-path pyproject.toml "project.optional-dependencies.ruff[0]")
+          uv pip install lm-eval[wandb, openai]@git+https://github.com/EleutherAI/lm-evaluation-harness.git@45823914a3e445076a1ba12c9b1501c98e3dd20d
         continue-on-error: false
           
       - name: Linting with Ruff

--- a/.github/workflows/merge_checks.yaml
+++ b/.github/workflows/merge_checks.yaml
@@ -57,7 +57,6 @@ jobs:
       - name: Set up Environment
         id: setup
         run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
           python3 -m venv .venv
           echo "VIRTUAL_ENV=$HOME/.venv" >> $GITHUB_ENV
         continue-on-error: false
@@ -66,7 +65,7 @@ jobs:
         id: install_package
         run: |
           . .venv/bin/activate
-          pip install "lm_buddy[dev] @ ."
+          pip install ".[dev]"
         continue-on-error: false
 
       - name: Unit Tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ To do so, follow the steps:
 1. Compile a locked version of the package requirements from the `pyproject.toml` file, 
 which will create a `requirements.txt` file in the `lm-buddy` repository.
 This can be done using multiple open-source tools, such as
-[pip-tools](https://github.com/jazzband/pip-tools) or [uv](https://github.com/astral-sh/uv),
+[pip-tools](https://github.com/jazzband/pip-tools),
 as shown below:
 
     ```
@@ -42,9 +42,6 @@ as shown below:
     pip install pip-tools
     pip-compile -o requirements.txt pyproject.toml
 
-    # uv
-    pip install uv
-    uv pip compile -o requirements.txt pyproject.toml
     ```
 
 2. When submitting a job to a Ray cluster, specify in the Ray runtime environment the following:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "trl==0.7.10",
     "bitsandbytes==0.42.0",
     # Evaluation frameworks
-    "lm-eval[wandb,openai]@git+https://github.com/EleutherAI/lm-evaluation-harness.git@45823914a3e445076a1ba12c9b1501c98e3dd20d",
+    "lm-eval @ git+https://github.com/EleutherAI/lm-evaluation-harness.git@45823914a3e445076a1ba12c9b1501c98e3dd20d",
     "einops==0.7.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "pydantic-yaml==1.2.0",
     "ray[default]==2.9.3",
     # HuggingFace
-    "datasets=>2.16.1",
+    "datasets>=2.16.1",
     "transformers==4.36.2",
     "accelerate==0.26.1",
     "peft==0.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "trl==0.7.10",
     "bitsandbytes==0.42.0",
     # Evaluation frameworks
-    "lm-eval[wandb,openai]@git+https://github.com/:EleutherAI/lm-evaluation-harness/commit/292e581",
+    "lm-eval[wandb,openai]@git+https://github.com/EleutherAI/lm-evaluation-harness/commit/292e581",
     "einops==0.7.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "trl==0.7.10",
     "bitsandbytes==0.42.0",
     # Evaluation frameworks
-    "lm-eval[wandb,openai]@git+https://github.com/EleutherAI/lm-evaluation-harness/commit/292e581",
+    "lm-eval[wandb,openai]@git+https://github.com/EleutherAI/lm-evaluation-harness.git@45823914a3e445076a1ba12c9b1501c98e3dd20d",
     "einops==0.7.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "trl==0.7.10",
     "bitsandbytes==0.42.0",
     # Evaluation frameworks
-    "lm-eval[wandb, openai]@git+https://github.com/EleutherAI/lm-evaluation-harness.git@45823914a3e445076a1ba12c9b1501c98e3dd20d",
+    "lm-eval @ git+https://github.com/EleutherAI/lm-evaluation-harness@45823914a3e445076a1ba12c9b1501c98e3dd20d",
     "einops==0.7.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "trl==0.7.10",
     "bitsandbytes==0.42.0",
     # Evaluation frameworks
-    "lm-eval[wandb,openai]@git@github.com:EleutherAI/lm-evaluation-harness/commit/292e581",
+    "lm-eval[wandb,openai]@git+https://github.com/:EleutherAI/lm-evaluation-harness/commit/292e581",
     "einops==0.7.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lm-buddy"
-version = "0.2.6"
+version = "0.2.7"
 authors = [
     { name = "Sean Friedowitz", email = "sean@mozilla.ai" },
     { name = "Aaron Gonzales", email = "aaron@mozilla.ai" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "click==8.1.7",
     "torch==2.1.2",
     "scipy==1.10.1",
-    "wandb==0.16.2",
+    "wandb==0.16.3",
     "protobuf==3.20.2",
     "urllib3>=1.26.18,<2",
     "pydantic==2.6.0",
@@ -35,8 +35,7 @@ dependencies = [
     "trl==0.7.10",
     "bitsandbytes==0.42.0",
     # Evaluation frameworks
-#    "lm-eval[wandb, openai]@git+https://github.com/EleutherAI/lm-evaluation-harness.git@45823914a3e445076a1ba12c9b1501c98e3dd20d",
-    #"lm-eval @ git+https://github.com/EleutherAI/lm-evaluation-harness.git",
+    "lm-eval[wandb, openai]@git+https://github.com/EleutherAI/lm-evaluation-harness.git@45823914a3e445076a1ba12c9b1501c98e3dd20d",
     "einops==0.7.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,14 +28,14 @@ dependencies = [
     "pydantic-yaml==1.2.0",
     "ray[default]==2.9.3",
     # HuggingFace
-    "datasets==2.16.1",
+    "datasets=>2.16.1",
     "transformers==4.36.2",
     "accelerate==0.26.1",
     "peft==0.7.1",
     "trl==0.7.10",
     "bitsandbytes==0.42.0",
     # Evaluation frameworks
-    "lm-eval[openai]==0.4.1",
+    "lm-eval[wandb,openai]@git@github.com:EleutherAI/lm-evaluation-harness/commit/292e581",
     "einops==0.7.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ dependencies = [
     "trl==0.7.10",
     "bitsandbytes==0.42.0",
     # Evaluation frameworks
-    "lm-eval@git+https://github.com/EleutherAI/lm-evaluation-harness.git@45823914a3e445076a1ba12c9b1501c98e3dd20d",
+#    "lm-eval[wandb, openai]@git+https://github.com/EleutherAI/lm-evaluation-harness.git@45823914a3e445076a1ba12c9b1501c98e3dd20d",
+    "lm-eval @ git+https://github.com/EleutherAI/lm-evaluation-harness.git",
     "einops==0.7.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "bitsandbytes==0.42.0",
     # Evaluation frameworks
 #    "lm-eval[wandb, openai]@git+https://github.com/EleutherAI/lm-evaluation-harness.git@45823914a3e445076a1ba12c9b1501c98e3dd20d",
-    "lm-eval @ git+https://github.com/EleutherAI/lm-evaluation-harness.git",
+    #"lm-eval @ git+https://github.com/EleutherAI/lm-evaluation-harness.git",
     "einops==0.7.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "trl==0.7.10",
     "bitsandbytes==0.42.0",
     # Evaluation frameworks
-    "lm-eval @ git+https://github.com/EleutherAI/lm-evaluation-harness.git@45823914a3e445076a1ba12c9b1501c98e3dd20d",
+    "lm-eval@git+https://github.com/EleutherAI/lm-evaluation-harness.git@45823914a3e445076a1ba12c9b1501c98e3dd20d",
     "einops==0.7.0",
 ]
 


### PR DESCRIPTION
## What's changing

We'd like to pin lm-harness to the hash resolving trust_remote_code (see issue here:https://github.com/mozilla-ai/lm-buddy/issues/49), and also updating to include wandb for logging

## How to test it

## Related Jira Ticket

## Additional notes for reviewers

