### PR TITLE
Bumping the library version and pinning lm-eval-harness to a PyPI Distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lm-buddy"
-version = "0.2.7"
+version = "0.2.8"
 authors = [
     { name = "Sean Friedowitz", email = "sean@mozilla.ai" },
     { name = "Aaron Gonzales", email = "aaron@mozilla.ai" },
@@ -35,7 +35,7 @@ dependencies = [
     "trl==0.7.10",
     "bitsandbytes==0.42.0",
     # Evaluation frameworks
-    "lm-eval @ git+https://github.com/EleutherAI/lm-evaluation-harness@45823914a3e445076a1ba12c9b1501c98e3dd20d",
+    "lm-eval==0.4.1",
     "einops==0.7.0",
 ]
 


### PR DESCRIPTION
## What's changing

We wanted to pin lm-eval to a git hash to encompass the latest changes, but PyPI doesn't allow to publish packages with git-hash pinned dependencies, so reverting for now so we can update the PyPI version with the latest Ray on publish. 

## How to test it

## Related Jira Ticket

## Additional notes for reviewers
See errors here: https://github.com/mozilla-ai/lm-buddy/actions/runs/8238935806/job/22531036074
