### PR TITLE
Add PyPI docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,5 +77,8 @@ The publishing workflow can be triggered in two ways:
 1. Manually triggered on the GitHub Actions UI, which publishes the package to TestPyPI, or
 2. Triggered by the creation of a GitHub release, which publishes to real PyPI.
 
-When creating a GitHub release, make sure that the tag used for the release
-matches the version of the target code branch.
+Note that there are some limitations on publishing to PyPI which are relevant to `lm-buddy`. 
+For instance, we can't publish a package that has git-hash pinned dependencies because [PyPI requirements dictate](https://github.com/pypi/warehouse/blob/fca2efaee722cceef87e3e61926426de090db03b/warehouse/forklift/legacy.py#L280) that all packages be version-based.  
+
+When creating a GitHub release, make sure that the tag you create in the GitHub release UI
+matches the version of the target code branch specified in `pyproject.toml`.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,11 +3,11 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to the documentation!
+lm-buddy documentation
 ====================================
 LM Buddy is a collection of jobs for finetuning and evaluating open-source (large) language models.
 The library makes use of YAML-based configuration files as inputs to CLI commands for each job,
-and tracks input/output data with [Weights & Biases](https://docs.wandb.ai/) artifacts.
+and tracks input/output data with Weights and Biases artifacts.
 
 Getting Started
 ---------------


### PR DESCRIPTION
## What's changing

We learned that we can't publish git-hash pinned dependencies, so adding that for the publishing section and cleaning up some docs formatting. 

## How to test it

## Related Jira Ticket

## Additional notes for reviewers

