### PR TITLE
Update lm-eval version and API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lm-buddy"
-version = "0.3.0"
+version = "0.3.1"
 authors = [
     { name = "Sean Friedowitz", email = "sean@mozilla.ai" },
     { name = "Aaron Gonzales", email = "aaron@mozilla.ai" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,14 +29,14 @@ dependencies = [
     "pydantic-yaml==1.2.0",
     "ray[default]==2.9.3",
     # HuggingFace
-    "datasets>=2.16.1",
+    "datasets>=2.17.1",
     "transformers==4.36.2",
     "accelerate==0.26.1",
     "peft==0.7.1",
     "trl==0.7.10",
     "bitsandbytes==0.42.0",
     # Evaluation frameworks
-    "lm-eval==0.4.1",
+    "lm-eval==0.4.2",
     "einops==0.7.0",
     "fschat==0.2.36",
     "openai==1.3.9",

--- a/src/lm_buddy/jobs/_entrypoints/lm_harness.py
+++ b/src/lm_buddy/jobs/_entrypoints/lm_harness.py
@@ -86,7 +86,6 @@ def load_and_evaluate(
     config: LMHarnessJobConfig,
     artifact_loader: ArtifactLoader,
 ) -> dict[str, list[tuple[str, float]]]:
-    print("Initializing lm-harness tasks...")
 
     llm = load_harness_model(config, artifact_loader)
     eval_results = lm_eval.simple_evaluate(

--- a/src/lm_buddy/jobs/_entrypoints/lm_harness.py
+++ b/src/lm_buddy/jobs/_entrypoints/lm_harness.py
@@ -87,7 +87,6 @@ def load_and_evaluate(
     artifact_loader: ArtifactLoader,
 ) -> dict[str, list[tuple[str, float]]]:
     print("Initializing lm-harness tasks...")
-    lm_eval.tasks.initialize_tasks()
 
     llm = load_harness_model(config, artifact_loader)
     eval_results = lm_eval.simple_evaluate(


### PR DESCRIPTION
## What's changing

LM-eval has [now been bumped](https://github.com/EleutherAI/lm-evaluation-harness/releases/tag/v0.4.2) to `0.4.2`, incorporating `trust_remote_code`=`True` as a default for a select set of curated datasets, removing the warning for those datasets specifically. Also bumping `datasets` as a result. 

In the change, we also remove the need to call `lm_eval.tasks.initialize_tasks()`

```python
import lm_eval

# optional--only need to instantiate separately if you want to pass custom path!
task_manager = TaskManager() # pass include_path="/path/to/my/custom/tasks" if desired

lm_eval.simple_evaluate(model=lm, tasks=["arc_easy"], task_manager=task_manager)
```

## How to test it

Run a test Ray job using the evaluate entrypoint to evaluate using some default params:

```yaml
# Model to evaluate
model:
  load_from: "tiiuae/falcon-7b"
  torch_dtype: "bfloat16"

# Settings specific to lm_harness.evaluate
evaluator (note this is still using the old API):
  tasks: ["arithmetic"]
  num_fewshot: 5
  limit: 10


quantization:
  load_in_4bit: True
  bnb_4bit_quant_type: "fp4"
  bnb_4bit_compute_dtype: "bfloat16"

# Tracking info for where to log the run results
tracking:
  name: "tiiuae-falcon-7b-trust"
  project: "vicki-entity"
  entity: "entity"
```

## Related Jira Ticket

## Additional notes for reviewers

