### PR TITLE
Reinstate uv for tests

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -33,7 +33,8 @@ jobs:
     - name: Set up Environment
       id: setup
       run: |
-        python3 -m venv .venv
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        uv venv
         echo "VIRTUAL_ENV=$HOME/.venv" >> $GITHUB_ENV
       continue-on-error: false
 
@@ -41,7 +42,7 @@ jobs:
       id: install_build_dependencies
       run: |
         . .venv/bin/activate
-        pip install ".[docs]"
+        uv pip install "lm-buddy[docs] @ ."
       continue-on-error: false 
 
     - name: Build Documentation

--- a/.github/workflows/merge_checks.yaml
+++ b/.github/workflows/merge_checks.yaml
@@ -32,8 +32,8 @@ jobs:
         id: install_dependencies
         run: |
           . .venv/bin/activate
-          pip install toml-cli
-          pip install $(toml get --toml-path pyproject.toml "project.optional-dependencies.ruff[0]")
+          uv pip install toml-cli
+          uv pip install $(toml get --toml-path pyproject.toml "project.optional-dependencies.ruff[0]")
         continue-on-error: false
           
       - name: Linting with Ruff
@@ -57,7 +57,8 @@ jobs:
       - name: Set up Environment
         id: setup
         run: |
-          python3 -m venv .venv
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          uv venv
           echo "VIRTUAL_ENV=$HOME/.venv" >> $GITHUB_ENV
         continue-on-error: false
 
@@ -65,7 +66,7 @@ jobs:
         id: install_package
         run: |
           . .venv/bin/activate
-          pip install ".[dev]"
+          uv pip install "lm_buddy[dev] @ ."
         continue-on-error: false
 
       - name: Unit Tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,14 +34,17 @@ To do so, follow the steps:
 1. Compile a locked version of the package requirements from the `pyproject.toml` file, 
 which will create a `requirements.txt` file in the `lm-buddy` repository.
 This can be done using multiple open-source tools, such as
-[pip-tools](https://github.com/jazzband/pip-tools),
+[pip-tools](https://github.com/jazzband/pip-tools),or [uv](https://github.com/astral-sh/uv)
 as shown below:
 
     ```
     # pip-tools
     pip install pip-tools
     pip-compile -o requirements.txt pyproject.toml
-
+    
+    # uv
+    pip install uv
+    uv pip compile -o requirements.txt pyproject.toml
     ```
 
 2. When submitting a job to a Ray cluster, specify in the Ray runtime environment the following:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lm-buddy"
-version = "0.3.1"
+version = "0.3.2"
 authors = [
     { name = "Sean Friedowitz", email = "sean@mozilla.ai" },
     { name = "Aaron Gonzales", email = "aaron@mozilla.ai" },


### PR DESCRIPTION
## What's changing

We can use UV again now that we don't use git-hash specified dependencies. See issue: https://github.com/mozilla-ai/lm-buddy/issues/79

## How to test it

## Related Jira Ticket

## Additional notes for reviewers

