### PR TITLE
Added S3 support for datasets, refactored asset loaders

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lm-buddy"
-version = "0.10.3"
+version = "0.10.4"
 authors = [
     { name = "Sean Friedowitz", email = "sean@mozilla.ai" },
     { name = "Aaron Gonzales", email = "aaron@mozilla.ai" },

--- a/src/lm_buddy/jobs/evaluation/lm_harness.py
+++ b/src/lm_buddy/jobs/evaluation/lm_harness.py
@@ -9,7 +9,7 @@ from loguru import logger
 
 from lm_buddy.configs.huggingface import AutoModelConfig
 from lm_buddy.configs.jobs.lm_harness import LMHarnessJobConfig, LocalChatCompletionsConfig
-from lm_buddy.jobs.asset_loader import HuggingFaceAssetLoader
+from lm_buddy.jobs.asset_loader import HuggingFaceModelLoader
 from lm_buddy.jobs.common import EvaluationResult
 from lm_buddy.tracking.artifact_utils import (
     ArtifactType,
@@ -37,10 +37,10 @@ def get_per_task_dataframes(
 
 def load_harness_model(config: LMHarnessJobConfig) -> HFLM | OpenaiCompletionsLM:
     # Instantiate the lm-harness LM class based on the provided model config type
-    hf_loader = HuggingFaceAssetLoader()
+    hf_model_loader = HuggingFaceModelLoader()
     match config.model:
         case AutoModelConfig() as model_config:
-            model_path, peft_path = hf_loader.resolve_peft_and_pretrained(model_config.path)
+            model_path, peft_path = hf_model_loader.resolve_peft_and_pretrained(model_config.path)
             quantization_kwargs: dict[str, Any] = (
                 config.quantization.model_dump() if config.quantization else {}
             )
@@ -56,7 +56,7 @@ def load_harness_model(config: LMHarnessJobConfig) -> HFLM | OpenaiCompletionsLM
             )
 
         case LocalChatCompletionsConfig() as local_config:
-            engine_path = hf_loader.resolve_asset_path(local_config.inference.engine)
+            engine_path = hf_model_loader.resolve_asset_path(local_config.inference.engine)
             return OpenaiCompletionsLM(
                 model=engine_path,
                 base_url=local_config.inference.base_url,

--- a/src/lm_buddy/jobs/finetuning.py
+++ b/src/lm_buddy/jobs/finetuning.py
@@ -11,7 +11,11 @@ from transformers import TrainingArguments
 from trl import SFTTrainer
 
 from lm_buddy.configs.jobs.finetuning import FinetuningJobConfig
-from lm_buddy.jobs.asset_loader import HuggingFaceAssetLoader
+from lm_buddy.jobs.asset_loader import (
+    HuggingFaceDatasetLoader,
+    HuggingFaceModelLoader,
+    HuggingFaceTokenizerLoader,
+)
 from lm_buddy.jobs.common import FinetuningResult, JobType
 from lm_buddy.preprocessing import format_dataset_with_prompt
 from lm_buddy.tracking.artifact_utils import (
@@ -30,11 +34,13 @@ def is_tracking_enabled(config: FinetuningJobConfig):
 
 def load_and_train(config: FinetuningJobConfig):
     # Load the HF assets from configurations
-    hf_loader = HuggingFaceAssetLoader()
-    model = hf_loader.load_pretrained_model(config.model, config.quantization)
-    tokenizer = hf_loader.load_pretrained_tokenizer(config.tokenizer)
+    hf_model_loader = HuggingFaceModelLoader()
+    hf_tok_loader = HuggingFaceTokenizerLoader()
+    hf_dataset_loader = HuggingFaceDatasetLoader()
+    model = hf_model_loader.load_pretrained_model(config.model, config.quantization)
+    tokenizer = hf_tok_loader.load_pretrained_tokenizer(config.tokenizer)
 
-    datasets = hf_loader.load_and_split_dataset(config.dataset)
+    datasets = hf_dataset_loader.load_and_split_dataset(config.dataset)
     if config.dataset.prompt_template is not None:
         for split, dataset in datasets.items():
             datasets[split] = format_dataset_with_prompt(

--- a/src/lm_buddy/paths.py
+++ b/src/lm_buddy/paths.py
@@ -13,6 +13,7 @@ class PathPrefix(str, Enum):
     FILE = "file://"
     HUGGINGFACE = "hf://"
     WANDB = "wandb://"
+    S3 = "s3://"
 
 
 def strip_path_prefix(path: str) -> str:
@@ -46,6 +47,11 @@ def validate_asset_path(path: str) -> "AssetPath":
             raise ValueError(f"'{raw_path}' is not a valid HuggingFace repo ID.")
     elif path.startswith(PathPrefix.WANDB):
         # TODO: Validate the W&B path structure?
+        pass
+    elif path.startswith(PathPrefix.S3):
+        # TODO: Validate the S3 path structure?
+        # e.g. if the assumption is we always want a file or a dir, we could
+        # use https://s3pathlib.readthedocs.io to verify (.is_file() or ._is_dir())
         pass
     else:
         allowed_prefixes = {x.value for x in PathPrefix}

--- a/tests/unit/jobs/test_asset_loader.py
+++ b/tests/unit/jobs/test_asset_loader.py
@@ -2,12 +2,12 @@ import torch
 from datasets import Dataset, DatasetDict
 
 from lm_buddy.configs.huggingface import AutoModelConfig, DatasetConfig
-from lm_buddy.jobs.asset_loader import HuggingFaceAssetLoader
+from lm_buddy.jobs.asset_loader import HuggingFaceDatasetLoader, HuggingFaceModelLoader
 from lm_buddy.paths import format_file_path
 
 
 def test_dataset_loading(xyz_dataset_path):
-    hf_loader = HuggingFaceAssetLoader()
+    hf_loader = HuggingFaceDatasetLoader()
 
     asset_path = format_file_path(xyz_dataset_path)
     dataset_config = DatasetConfig(path=asset_path, test_size=0.2, seed=0)
@@ -21,7 +21,7 @@ def test_dataset_loading(xyz_dataset_path):
 
 
 def test_model_loading(llm_model_path):
-    hf_loader = HuggingFaceAssetLoader()
+    hf_loader = HuggingFaceModelLoader()
 
     asset_path = format_file_path(llm_model_path)
     model_config = AutoModelConfig(path=asset_path, torch_dtype=torch.bfloat16)


### PR DESCRIPTION
## What's changing

- Added S3 support for datasets
- Refactored the asset loaders to (1) support S3 datasets and (2) be asset-specific. We now have one class for datasets, one for models/configs, one for tokenizers.

## How to test it
- Used pytest for backwards compatibility.
- Manually tested S3 dataset loading in the prometheus job (we might want to rely on localstack for testing)

