### PR TITLE
New huggingface eval for the summarization use case with rouge, meteor, and bertscore

### DIFF
--- a/examples/configs/evaluation/hf_evaluate_config.yaml
+++ b/examples/configs/evaluation/hf_evaluate_config.yaml
@@ -1,25 +1,65 @@
 name: "lm-buddy-hf-evaluate"
 
+# Input dataset path
 dataset:
   path: "s3://platform-storage/datasets/dialogsum"
 
-# Settings specific to hf_evaluate
-evaluation:
-  metrics: ["rouge", "bertscore", "meteor"]
-  # enable/disable tqdm to track eval progress
-  enable_tqdm: False
-  # rely on HF pipeline for summarization
-  use_pipeline: True
 
-# Model to evaluate
+# Settings specific to the hf_evaluate entrypoint
+evaluation:
+  # metrics to be used for the evaluation
+  # (you can add "rouge", "meteor", and "bertscore" atm)
+  metrics: ["rouge", "meteor"]
+  # enable/disable tqdm to track eval progress
+  # (useful when running interactively, noisy on ray logs)
+  enable_tqdm: True
+  # rely on HF pipeline for summarization (ignored if using OAI API)
+  use_pipeline: True
+  # perform inference / evaluation on the first max_samples only
+  max_samples: 10
+  # output file path
+  # - if you provide a path complete with a filename, results will be stored in it
+  # - if you provide a dir, results will be stored in <dir>/<config.name>/eval_results.json
+  # - if you don't provide a storage path, results will be stored locally (see ~/.lm-buddy/results)
+  # storage_path: "s3://platform-storage/experiments/results/"
+
+# Model to evaluate. Choose one of the following options by uncommenting it
+
+# 1. Local model
+#    - Provide model path to load the model locally
+#    - Make sure you add quantization details (see below) if the model is too large
+#    - Optionally, add a tokenizer (the one matching the specified model name is the default)
 model:
   path: "hf://facebook/bart-large-cnn"
 
-quantization:
-  load_in_4bit: True
-  bnb_4bit_quant_type: "fp4"
+# # 2. OpenAI
+# #    - The base_url is fixed
+# #    - Choose an engine name (see https://platform.openai.com/docs/models)
+# #    - Customize the system prompt if needed
+# model:
+#   inference:
+#     base_url: "https://api.openai.com/v1"
+#     engine: "oai://gpt-4-turbo"
+#     system_prompt: "You are a helpful assistant, expert in text summarization. For every prompt you receive, provide a summary of its contents in at most two sentences."
+#     max_retries: 3
 
-# # Tracking info for where to log the run results
+# # 3. OpenAI - compatible model
+# #    - Works with local/remote vLLM-served models and llamafiles
+# #    - Provide base_url and engine
+# #    - Customize the system prompt if needed
+# model:
+#   inference:
+#     base_url: "http://localhost:8081/v1"
+#     engine: "hf://mistralai/mistral-7b-instruct-v0.2"
+#     system_prompt: "You are a helpful assistant, expert in text summarization. For every prompt you receive, provide a summary of its contents in at most two sentences."
+#     max_retries: 3
+
+# Quantization (use it if you are dealing with models too large to fit in RAM)
+# quantization:
+#   load_in_4bit: True
+#   bnb_4bit_quant_type: "fp4"
+
+# Tracking info for where to log the run results
 # tracking:
 #   project: "lm-buddy-examples"
 #   entity: "sample"

--- a/examples/configs/evaluation/hf_evaluate_config.yaml
+++ b/examples/configs/evaluation/hf_evaluate_config.yaml
@@ -1,0 +1,25 @@
+name: "lm-buddy-hf-evaluate"
+
+dataset:
+  path: "s3://platform-storage/datasets/dialogsum"
+
+# Settings specific to hf_evaluate
+evaluation:
+  metrics: ["rouge"]
+  # enable/disable tqdm to track eval progress
+  enable_tqdm: False
+  # rely on HF pipeline for summarization
+  use_pipeline: True
+
+# Model to evaluate
+model:
+  path: "hf://facebook/bart-large-cnn"
+
+quantization:
+  load_in_4bit: True
+  bnb_4bit_quant_type: "fp4"
+
+# # Tracking info for where to log the run results
+# tracking:
+#   project: "lm-buddy-examples"
+#   entity: "sample"

--- a/examples/configs/evaluation/hf_evaluate_config.yaml
+++ b/examples/configs/evaluation/hf_evaluate_config.yaml
@@ -5,7 +5,7 @@ dataset:
 
 # Settings specific to hf_evaluate
 evaluation:
-  metrics: ["rouge"]
+  metrics: ["rouge", "bertscore", "meteor"]
   # enable/disable tqdm to track eval progress
   enable_tqdm: False
   # rely on HF pipeline for summarization

--- a/examples/configs/evaluation/hf_evaluate_inference_server_config.yaml
+++ b/examples/configs/evaluation/hf_evaluate_inference_server_config.yaml
@@ -1,4 +1,4 @@
-name: "lm-buddy-hf-evaluate"
+name: "lm-buddy-hf-evaluate-is"
 
 # Input dataset path
 dataset:
@@ -22,14 +22,13 @@ evaluation:
   # - if you don't provide a storage path, results will be stored locally (see ~/.lm-buddy/results)
   # storage_path: "s3://platform-storage/experiments/results/"
 
-# Model to evaluate (local).
-# - Provide model path to load the model locally
-# - Make sure you add quantization details (see below) if the model is too large
-# - Optionally, add a tokenizer (the one matching the specified model name is the default)
+# Model to evaluate (OpenAI-compatible API)
+# - Works with local/remote vLLM-served models and llamafiles
+# - Provide base_url and engine
+# - Customize the system prompt if needed
 model:
-  path: "hf://facebook/bart-large-cnn"
-
-# Quantization (use it if you are dealing with models too large to fit in RAM)
-# quantization:
-#   load_in_4bit: True
-#   bnb_4bit_quant_type: "fp4"
+  inference:
+    base_url: "http://localhost:8081/v1"
+    engine: "hf://mistralai/mistral-7b-instruct-v0.2"
+    system_prompt: "You are a helpful assistant, expert in text summarization. For every prompt you receive, provide a summary of its contents in at most two sentences."
+    max_retries: 3

--- a/examples/configs/evaluation/hf_evaluate_openai_config.yaml
+++ b/examples/configs/evaluation/hf_evaluate_openai_config.yaml
@@ -1,4 +1,4 @@
-name: "lm-buddy-hf-evaluate"
+name: "lm-buddy-hf-evaluate-oai"
 
 # Input dataset path
 dataset:
@@ -22,14 +22,13 @@ evaluation:
   # - if you don't provide a storage path, results will be stored locally (see ~/.lm-buddy/results)
   # storage_path: "s3://platform-storage/experiments/results/"
 
-# Model to evaluate (local).
-# - Provide model path to load the model locally
-# - Make sure you add quantization details (see below) if the model is too large
-# - Optionally, add a tokenizer (the one matching the specified model name is the default)
+# Model to evaluate (OpenAI)
+# - The base_url is fixed
+# - Choose an engine name (see https://platform.openai.com/docs/models)
+# - Customize the system prompt if needed
 model:
-  path: "hf://facebook/bart-large-cnn"
-
-# Quantization (use it if you are dealing with models too large to fit in RAM)
-# quantization:
-#   load_in_4bit: True
-#   bnb_4bit_quant_type: "fp4"
+  inference:
+    base_url: "https://api.openai.com/v1"
+    engine: "oai://gpt-4-turbo"
+    system_prompt: "You are a helpful assistant, expert in text summarization. For every prompt you receive, provide a summary of its contents in at most two sentences."
+    max_retries: 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools == 69.5.1"]
+requires = ["setuptools==69.5.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 61.0"]
+requires = ["setuptools == 69.5.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "pydantic-yaml==1.2.0",
     "ray[default]==2.9.3",
     "loguru==0.7.2",
-    "s3fs=2024.6.0",
+    "s3fs",
     # HuggingFace
     "datasets>=2.17.1",
     "transformers==4.36.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lm-buddy"
-version = "0.10.4"
+version = "0.10.5"
 authors = [
     { name = "Sean Friedowitz", email = "sean@mozilla.ai" },
     { name = "Aaron Gonzales", email = "aaron@mozilla.ai" },
@@ -37,6 +37,7 @@ dependencies = [
     "peft==0.7.1",
     "trl==0.7.10",
     "bitsandbytes==0.42.0",
+    "bert_score==0.3.13",
     # Evaluation frameworks
     "lm-eval==0.4.2",
     "einops==0.7.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "pydantic-yaml==1.2.0",
     "ray[default]==2.9.3",
     "loguru==0.7.2",
+    "s3fs=2024.6.0",
     # HuggingFace
     "datasets>=2.17.1",
     "transformers==4.36.2",

--- a/src/lm_buddy/buddy.py
+++ b/src/lm_buddy/buddy.py
@@ -3,12 +3,14 @@ import wandb
 from lm_buddy.configs.jobs import (
     EvaluationJobConfig,
     FinetuningJobConfig,
+    HuggingFaceEvalJobConfig,
     JobConfig,
     LMHarnessJobConfig,
     PrometheusJobConfig,
     RagasJobConfig,
 )
 from lm_buddy.jobs.common import EvaluationResult, FinetuningResult, JobType
+from lm_buddy.jobs.evaluation.hf_evaluate import run_hf_evaluation
 from lm_buddy.jobs.evaluation.lm_harness import run_lm_harness
 from lm_buddy.jobs.evaluation.prometheus import run_prometheus
 from lm_buddy.jobs.evaluation.ragas import run_ragas
@@ -66,6 +68,8 @@ class LMBuddy:
                 result = run_prometheus(prometheus_config)
             case RagasJobConfig() as ragas_config:
                 result = run_ragas(ragas_config)
+            case HuggingFaceEvalJobConfig() as hf_eval_config:
+                result = run_hf_evaluation(hf_eval_config)
             case _:
                 raise ValueError(f"Invlid configuration for evaluation: {type(config)}")
         self._generate_artifact_lineage(config, result.artifacts, JobType.EVALUATION)

--- a/src/lm_buddy/cli/evaluate.py
+++ b/src/lm_buddy/cli/evaluate.py
@@ -2,7 +2,12 @@ import click
 
 from lm_buddy import LMBuddy
 from lm_buddy.cli.utils import parse_config_option
-from lm_buddy.configs.jobs import LMHarnessJobConfig, PrometheusJobConfig, RagasJobConfig
+from lm_buddy.configs.jobs import (
+    HuggingFaceEvalJobConfig,
+    LMHarnessJobConfig,
+    PrometheusJobConfig,
+    RagasJobConfig,
+)
 
 
 @click.group(name="evaluate", help="Run an LM Buddy evaluation job.")
@@ -30,5 +35,13 @@ def prometheus_command(config: str) -> None:
 @click.option("--config", type=str)
 def ragas_command(config: str) -> None:
     config = parse_config_option(RagasJobConfig, config)
+    buddy = LMBuddy()
+    buddy.evaluate(config)
+
+
+@group.command("huggingface", help="Run the HuggingFace evaluation job.")
+@click.option("--config", type=str)
+def huggingface_command(config: str) -> None:
+    config = parse_config_option(HuggingFaceEvalJobConfig, config)
     buddy = LMBuddy()
     buddy.evaluate(config)

--- a/src/lm_buddy/configs/jobs/__init__.py
+++ b/src/lm_buddy/configs/jobs/__init__.py
@@ -1,10 +1,13 @@
 from lm_buddy.configs.jobs.common import JobConfig
 from lm_buddy.configs.jobs.finetuning import FinetuningJobConfig
+from lm_buddy.configs.jobs.hf_evaluate import HuggingFaceEvalJobConfig
 from lm_buddy.configs.jobs.lm_harness import LMHarnessJobConfig
 from lm_buddy.configs.jobs.prometheus import PrometheusJobConfig
 from lm_buddy.configs.jobs.ragas import RagasJobConfig
 
-EvaluationJobConfig = LMHarnessJobConfig | PrometheusJobConfig | RagasJobConfig
+EvaluationJobConfig = (
+    LMHarnessJobConfig | PrometheusJobConfig | RagasJobConfig | HuggingFaceEvalJobConfig
+)
 
 __all__ = [
     "JobConfig",
@@ -12,5 +15,6 @@ __all__ = [
     "LMHarnessJobConfig",
     "PrometheusJobConfig",
     "RagasJobConfig",
+    "HuggingFaceEvalJobConfig",
     "EvaluationJobConfig",
 ]

--- a/src/lm_buddy/configs/jobs/hf_evaluate.py
+++ b/src/lm_buddy/configs/jobs/hf_evaluate.py
@@ -1,0 +1,70 @@
+from pydantic import Field, conlist, field_validator, model_validator
+
+from lm_buddy.configs.common import LMBuddyConfig
+from lm_buddy.configs.huggingface import (
+    AutoModelConfig,
+    AutoTokenizerConfig,
+    DatasetConfig,
+    QuantizationConfig,
+)
+from lm_buddy.configs.jobs.common import JobConfig
+from lm_buddy.configs.vllm import VLLMCompletionsConfig
+from lm_buddy.paths import AssetPath
+
+
+class HuggingFaceEvaluationConfig(LMBuddyConfig):
+    """Misc settings provided to an lm-harness evaluation job."""
+
+    metrics: conlist(str, min_length=1)
+    use_pipeline: bool = False
+    enable_tqdm: bool = False
+
+
+class HuggingFaceEvalJobConfig(JobConfig):
+    """Configuration to run a HuggingFace evaluation job."""
+
+    dataset: DatasetConfig = Field(
+        description="Dataset of text completions to evaluate using the Prometheus judge model."
+    )
+    evaluation: HuggingFaceEvaluationConfig
+    model: AutoModelConfig | VLLMCompletionsConfig
+    quantization: QuantizationConfig | None = None
+    tokenizer: AutoTokenizerConfig
+
+    @model_validator(mode="before")
+    def ensure_tokenizer_config(cls, values):
+        """Set the tokenizer to the model path when not explicitly provided."""
+        if values.get("tokenizer") is None:
+            values["tokenizer"] = {}
+            match values["model"]:
+                case str() as model_path:
+                    values["tokenizer"]["path"] = model_path
+                case dict() as model_data:
+                    values["tokenizer"]["path"] = model_data["path"]
+                case AutoModelConfig() as model_config:
+                    values["tokenizer"]["path"] = model_config.path
+                # No fallback necessary, downstream validation will flag invalid model types
+        return values
+
+    @field_validator("model", mode="before")
+    def validate_model_arg(cls, x):
+        """Allow for passing just a path string as the model argument."""
+        if isinstance(x, str):
+            return AutoModelConfig(path=x)
+        return x
+
+    @field_validator("tokenizer", mode="before")
+    def validate_tokenizer_arg(cls, x):
+        """Allow for passing just a path string as the tokenizer argument."""
+        if isinstance(x, str):
+            return AutoTokenizerConfig(path=x)
+        return x
+
+    def asset_paths(self) -> list[AssetPath]:
+        match self.model:
+            case AutoModelConfig() as config:
+                return {self.dataset.path, config.path, self.tokenizer.path}
+            case VLLMCompletionsConfig() as config if config.inference.engine is not None:
+                return {self.dataset.path, config.inference.engine, self.tokenizer.path}
+            case _:
+                return {}

--- a/src/lm_buddy/configs/vllm.py
+++ b/src/lm_buddy/configs/vllm.py
@@ -12,11 +12,17 @@ class InferenceServerConfig(LMBuddyConfig):
 
     Note: This configuration is intended to be generic and not bound to the interface
     of any specific training/evaluation framework. See `LocalChatCompletionConfig`
-    or `vLLMCompleptionsConfig` for intended usage alongside a third-party framework.
+    or `vLLMCompletionsConfig` for intended usage alongside a third-party framework.
     """
 
     base_url: str
     engine: AssetPath
+
+    # optional system prompt to be used by default in chat completions
+    system_prompt: str | None = None
+
+    # max number of retries when communication with server fails
+    max_retries: int | None = None
 
 
 class VLLMCompletionsConfig(LMBuddyConfig):

--- a/src/lm_buddy/jobs/asset_loader.py
+++ b/src/lm_buddy/jobs/asset_loader.py
@@ -45,7 +45,7 @@ class HuggingFaceAssetLoader:
         The returned string has its `PathPrefix` stripped away..
         """
         raw_path = strip_path_prefix(path)
-        if path.startswith((PathPrefix.FILE, PathPrefix.HUGGINGFACE)):
+        if path.startswith((PathPrefix.FILE, PathPrefix.HUGGINGFACE, PathPrefix.OPENAI)):
             return raw_path
         elif path.startswith(PathPrefix.WANDB):
             artifact = get_artifact_from_api(raw_path)

--- a/src/lm_buddy/jobs/asset_loader.py
+++ b/src/lm_buddy/jobs/asset_loader.py
@@ -128,7 +128,6 @@ class HuggingFaceModelLoader(HuggingFaceAssetLoader):
 
         # load config first to get the model type
         model_config = self.load_pretrained_config(config)
-        # print(model_config)
 
         if getattr(model_config, "model_type") in MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING_NAMES:
             automodel_class = AutoModelForSeq2SeqLM
@@ -137,7 +136,6 @@ class HuggingFaceModelLoader(HuggingFaceAssetLoader):
         else:
             logger.info("Model type not supported. Trying AutoModelForCausalLM")
             automodel_class = AutoModelForCausalLM
-        # print(automodel_class)
 
         return automodel_class.from_pretrained(
             pretrained_model_name_or_path=model_path,

--- a/src/lm_buddy/jobs/evaluation/hf_evaluate.py
+++ b/src/lm_buddy/jobs/evaluation/hf_evaluate.py
@@ -1,0 +1,98 @@
+"""
+lm-buddy entrypoint to run summary evaluation using huggingface eval
+"""
+
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import torch
+from datasets import Dataset
+from loguru import logger
+from tqdm import tqdm
+from transformers import AutoModelForCausalLM, AutoModelForSeq2SeqLM, AutoTokenizer, pipeline
+
+from lm_buddy.configs.jobs.hf_evaluate import HuggingFaceEvalJobConfig
+from lm_buddy.constants import LM_BUDDY_RESULTS_PATH
+from lm_buddy.jobs.asset_loader import (
+    HuggingFaceDatasetLoader,
+    HuggingFaceModelLoader,
+    HuggingFaceTokenizerLoader,
+)
+from lm_buddy.jobs.common import EvaluationResult
+
+
+@dataclass
+class BadResponseError(Exception):
+    def __init__(self, message, error=None):
+        self.message = message
+        self.error = error
+
+
+def run_eval(config: HuggingFaceEvalJobConfig) -> Path:
+    # Init loaders
+    hf_dataset_loader = HuggingFaceDatasetLoader()
+    hf_model_loader = HuggingFaceModelLoader()
+    hf_tokenizer_loader = HuggingFaceTokenizerLoader()
+
+    # Load dataset given its URI
+    dataset = hf_dataset_loader.load_dataset(config.dataset)
+
+    # Enable / disable tqdm
+    input_samples = dataset.select(range(10))["examples"]
+    dataset_iterable = tqdm(input_samples) if config.evaluation.enable_tqdm else input_samples
+    results = []
+
+    # depending on config, use the summarizer pipeline or directly call the model
+    # for inference
+    if config.evaluation.use_pipeline:
+        logger.info("Using summarization pipeline")
+        summarizer = pipeline(
+            "summarization",
+            model=hf_model_loader.resolve_asset_path(config.model.path),
+            device=0 if torch.cuda.is_available() else -1,
+        )
+
+        t = time.time()
+        # for sample_txt in dataset_iterable:
+        #     # summarizer output is a list (1 element in this case) of dict with key = "summary_text"
+        #     results += summarizer(sample_txt, min_length=30, do_sample=False)
+
+        # alternative: run on the whole dataset
+        results = summarizer(dataset.select(range(10))["examples"], min_length=30, do_sample=False)
+
+        logger.info(f"Summarization performed in {time.time()-t} seconds")
+
+        results = [r["summary_text"] for r in results]
+
+    else:
+        logger.info("Using direct HF model invocation")
+
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        model = hf_model_loader.load_pretrained_model(config.model).to(device)
+        tokenizer = hf_tokenizer_loader.load_pretrained_tokenizer(config.tokenizer)
+
+        for sample_txt in dataset_iterable:
+            inputs = tokenizer(sample_txt, truncation=True, padding=True, return_tensors="pt").to(
+                device
+            )
+            generated_ids = model.generate(**inputs, max_new_tokens=256)
+            output_txt = tokenizer.batch_decode(generated_ids, skip_special_tokens=True)
+            results += output_txt
+
+    print(results)
+
+    return "/tmp/dataset"
+
+
+def run_hf_evaluation(config: HuggingFaceEvalJobConfig) -> EvaluationResult:
+    # Run eval and store output in local filename
+    result_dataset_path = run_eval(config)
+    logger.info(f"Prometheus evaluation dataset stored at {result_dataset_path}")
+
+    return EvaluationResult(
+        artifacts=[],
+        dataset_path=result_dataset_path,
+        tables={},
+    )

--- a/src/lm_buddy/jobs/evaluation/hf_evaluate.py
+++ b/src/lm_buddy/jobs/evaluation/hf_evaluate.py
@@ -109,7 +109,6 @@ def run_eval(config: HuggingFaceEvalJobConfig) -> Path:
 
     # run evaluation
     ground_truth = dataset["ground_truth"]
-    print(type(ground_truth))
     evaluation_results, evaluation_time = evaluate(
         predictions, ground_truth, config.evaluation.metrics
     )

--- a/src/lm_buddy/jobs/evaluation/hf_evaluate.py
+++ b/src/lm_buddy/jobs/evaluation/hf_evaluate.py
@@ -23,7 +23,7 @@ from lm_buddy.jobs.model_clients import (
     BaseModelClient,
     HuggingFaceModelClient,
     OpenAIModelClient,
-    PipelineModelClient,
+    SummarizationPipelineModelClient,
 )
 from lm_buddy.jobs.utils import timer
 
@@ -99,7 +99,7 @@ def run_eval(config: HuggingFaceEvalJobConfig) -> Path:
         # for inference
         if config.evaluation.use_pipeline:
             logger.info(f"Using summarization pipeline. Model: {model_name}")
-            model_client = PipelineModelClient(model_name, config.model)
+            model_client = SummarizationPipelineModelClient(model_name, config.model)
         else:
             logger.info(f"Using direct HF model invocation. Model: {model_name}")
             model_client = HuggingFaceModelClient(model_name, config)

--- a/src/lm_buddy/jobs/evaluation/metrics.py
+++ b/src/lm_buddy/jobs/evaluation/metrics.py
@@ -11,8 +11,10 @@ class EvaluationMetrics:
             "bertscore": self._bertscore,
         }
 
-        self._chosen_metrics = set(metrics).intersection(set(self._supported_metrics.keys()))
-        self._unsupported_metrics = set(metrics).difference(set(self._supported_metrics.keys()))
+        # chosen metrics are the intersection between the provided and the supporterd ones
+        self._chosen_metrics = set(metrics) & set(self._supported_metrics.keys())
+        # unsupported metrics are the difference between the provided and the supporterd ones
+        self._unsupported_metrics = set(metrics) - set(self._supported_metrics.keys())
 
         if len(self._chosen_metrics) == 0:
             logger.info("No valid metrics selected")
@@ -45,7 +47,7 @@ class EvaluationMetrics:
             evals["meteor"].append(ev.compute(predictions=[p], references=[r])["meteor"])
 
         # calculate mean
-        evals[f"meteor_mean"] = np.mean(evals["meteor"])
+        evals["meteor_mean"] = np.mean(evals["meteor"])
 
         return evals
 

--- a/src/lm_buddy/jobs/evaluation/metrics.py
+++ b/src/lm_buddy/jobs/evaluation/metrics.py
@@ -1,0 +1,70 @@
+import evaluate
+import numpy as np
+from loguru import logger
+
+
+class EvaluationMetrics:
+    def __init__(self, metrics):
+        self._supported_metrics = {
+            "rouge": self._rouge,
+            "meteor": self._meteor,
+            "bertscore": self._bertscore,
+        }
+
+        self._chosen_metrics = set(metrics).intersection(set(self._supported_metrics.keys()))
+        self._unsupported_metrics = set(metrics).difference(set(self._supported_metrics.keys()))
+
+        if len(self._chosen_metrics) == 0:
+            logger.info("No valid metrics selected")
+        else:
+            logger.info(f"Chosen metrics: {self._chosen_metrics}")
+
+        if len(self._unsupported_metrics) > 0:
+            logger.info(f"Unsupported metrics: {self._unsupported_metrics}")
+
+    def _rouge(self, pred, ref):
+        ev = evaluate.load("rouge")
+
+        # compute with use_aggregator = False to get individual scores
+        evals = ev.compute(predictions=pred, references=ref, use_aggregator=False)
+
+        # calculate mean for each of the submetrics (rouge1, rouge2, rougeL, rougeLsum)
+        for k in ["rouge1", "rouge2", "rougeL", "rougeLsum"]:
+            evals[f"{k}_mean"] = np.mean(evals[k])
+
+        return evals
+
+    def _meteor(self, pred, ref):
+        ev = evaluate.load("meteor")
+
+        # initialize dictionary with metric name
+        evals = {"meteor": []}
+
+        # run sample-wise evals (as default implementation only returns mean value)
+        for p, r in zip(pred, ref):
+            evals["meteor"].append(ev.compute(predictions=[p], references=[r])["meteor"])
+
+        # calculate mean
+        evals[f"meteor_mean"] = np.mean(evals["meteor"])
+
+        return evals
+
+    def _bertscore(self, pred, ref):
+        ev = evaluate.load("bertscore")
+
+        # calculate evals (the default is not to aggregate them)
+        evals = ev.compute(predictions=pred, references=ref, lang="en")
+
+        # calculate mean for each of the submetrics (precision, recall, f1)
+        for k in ["precision", "recall", "f1"]:
+            evals[f"{k}_mean"] = np.mean(evals[k])
+
+        return evals
+
+    def run_all(self, pred, ref):
+        results = {}
+
+        for metric in self._chosen_metrics:
+            results[metric] = self._supported_metrics[metric](pred, ref)
+
+        return results

--- a/src/lm_buddy/jobs/model_clients.py
+++ b/src/lm_buddy/jobs/model_clients.py
@@ -1,0 +1,111 @@
+from abc import abstractmethod
+
+import torch
+from loguru import logger
+from openai import OpenAI, OpenAIError
+from openai.types import Completion
+from transformers import pipeline
+
+from lm_buddy.configs.common import LMBuddyConfig
+from lm_buddy.configs.huggingface import AutoModelConfig
+from lm_buddy.configs.jobs.hf_evaluate import HuggingFaceEvalJobConfig
+from lm_buddy.configs.vllm import VLLMCompletionsConfig
+from lm_buddy.jobs.asset_loader import HuggingFaceModelLoader, HuggingFaceTokenizerLoader
+
+
+class BaseModelClient:
+    @abstractmethod
+    def __init__(self, model: str, config: LMBuddyConfig):
+        pass
+
+    @abstractmethod
+    def predict(self, prompt: str) -> str:
+        pass
+
+
+class PipelineModelClient(BaseModelClient):
+    def __init__(self, model: str, config: AutoModelConfig):
+        self._summarizer = pipeline(
+            "summarization",
+            model=model,
+            device=0 if torch.cuda.is_available() else -1,
+        )
+
+    def predict(self, prompt):
+        # summarizer output is a list (1 element in this case) of dict with key = "summary_text"
+        # TODO: bring summarizer parameters out at some point (not needed at the moment)
+        pred = self._summarizer(prompt, min_length=30, do_sample=False)
+        return pred[0]["summary_text"]
+
+
+class HuggingFaceModelClient(BaseModelClient):
+    def __init__(self, model: str, config: HuggingFaceEvalJobConfig):
+        self._config = config
+        self._device = "cuda" if torch.cuda.is_available() else "cpu"
+
+        hf_model_loader = HuggingFaceModelLoader()
+        hf_tokenizer_loader = HuggingFaceTokenizerLoader()
+        self._model = hf_model_loader.load_pretrained_model(config.model).to(self._device)
+        self._tokenizer = hf_tokenizer_loader.load_pretrained_tokenizer(config.tokenizer)
+
+    def predict(self, prompt):
+        inputs = self._tokenizer(prompt, truncation=True, padding=True, return_tensors="pt").to(
+            self._device
+        )
+        generated_ids = self._model.generate(**inputs, max_new_tokens=256)
+        return self._tokenizer.batch_decode(generated_ids, skip_special_tokens=True)[0]
+
+
+class OpenAIModelClient(BaseModelClient):
+    def __init__(self, model: str, config: VLLMCompletionsConfig):
+        self._config = config
+
+        hf_model_loader = HuggingFaceModelLoader()
+        self._engine = hf_model_loader.resolve_asset_path(config.inference.engine)
+        self._system = config.inference.system_prompt
+        self._client = OpenAI(base_url=model)
+
+    def _openai_chat_completion(
+        self,
+        config: VLLMCompletionsConfig,
+        client: OpenAI,
+        prompt: str,
+        system: str = "You are a helpful assisant.",
+    ) -> Completion:
+        """Connects to a remote OpenAI-API-compatible endpoint
+        and returns a chat completion holding the model's response.
+        """
+
+        return self._client.chat.completions.create(
+            model=self._engine,
+            messages=[{"role": "system", "content": system}, {"role": "user", "content": prompt}],
+            max_tokens=config.max_tokens,
+            frequency_penalty=config.frequency_penalty,
+            temperature=config.temperature,
+            top_p=config.top_p,
+        )
+
+    def _get_response_with_retries(
+        self,
+        config: VLLMCompletionsConfig,
+        prompt: str,
+    ) -> tuple[str, str]:
+        current_retry_attempt = 1
+        max_retries = 1 if config.inference.max_retries is None else config.inference.max_retries
+        while current_retry_attempt <= max_retries:
+            try:
+                response = self._openai_chat_completion(
+                    self._config, self._client, prompt, self._system
+                )
+                break
+            except OpenAIError as e:
+                logger.warning(f"{e.message}: " f"Retrying ({current_retry_attempt}/{max_retries})")
+                current_retry_attempt += 1
+                if current_retry_attempt > max_retries:
+                    raise e
+        return response
+
+    def predict(self, prompt):
+        response = self._get_response_with_retries(self._config, prompt)
+
+        return response.choices[0].message.content

--- a/src/lm_buddy/jobs/model_clients.py
+++ b/src/lm_buddy/jobs/model_clients.py
@@ -138,7 +138,7 @@ class OpenAIModelClient(BaseModelClient):
                 )
                 break
             except OpenAIError as e:
-                logger.warning(f"{e.message}: " f"Retrying ({current_retry_attempt}/{max_retries})")
+                logger.warning(f"{e.message}: Retrying ({current_retry_attempt}/{max_retries})")
                 current_retry_attempt += 1
                 if current_retry_attempt > max_retries:
                     raise e

--- a/src/lm_buddy/jobs/model_clients.py
+++ b/src/lm_buddy/jobs/model_clients.py
@@ -14,16 +14,34 @@ from lm_buddy.jobs.asset_loader import HuggingFaceModelLoader, HuggingFaceTokeni
 
 
 class BaseModelClient:
+    """
+    Abstract class for a model client, used to provide a uniform interface
+    (currentnly just a simple predict method) to models served in different
+    ways (e.g. HF models loaded locally, OpenAI endpoints, vLLM inference
+    servers, llamafile).
+    """
+
     @abstractmethod
     def __init__(self, model: str, config: LMBuddyConfig):
+        """
+        Used to initialize the model / inference service.
+        """
         pass
 
     @abstractmethod
     def predict(self, prompt: str) -> str:
+        """
+        Given a prompt, return a prediction.
+        """
         pass
 
 
-class PipelineModelClient(BaseModelClient):
+class SummarizationPipelineModelClient(BaseModelClient):
+    """
+    Model client for the huggingface summarization pipeline
+    (model is loaded locally).
+    """
+
     def __init__(self, model: str, config: AutoModelConfig):
         self._summarizer = pipeline(
             "summarization",
@@ -39,6 +57,14 @@ class PipelineModelClient(BaseModelClient):
 
 
 class HuggingFaceModelClient(BaseModelClient):
+    """
+    Model client for HF models (model is loaded locally, both Seq2SeqLM
+    and CausalLM are supported).
+    - Provide model path to load the model locally
+    - Make sure you add quantization details if the model is too large
+    - Optionally, add a tokenizer (the one matching the specified model name is the default)
+    """
+
     def __init__(self, model: str, config: HuggingFaceEvalJobConfig):
         self._config = config
         self._device = "cuda" if torch.cuda.is_available() else "cpu"
@@ -57,6 +83,19 @@ class HuggingFaceModelClient(BaseModelClient):
 
 
 class OpenAIModelClient(BaseModelClient):
+    """
+    Model client for models served via openai-compatible API.
+    For OpenAI models:
+    - The base_url is fixed
+    - Choose an engine name (see https://platform.openai.com/docs/models)
+    - Customize the system prompt if needed
+
+    For compatible models:
+    - Works with local/remote vLLM-served models and llamafiles
+    - Provide base_url and engine
+    - Customize the system prompt if needed
+    """
+
     def __init__(self, model: str, config: VLLMCompletionsConfig):
         self._config = config
 

--- a/src/lm_buddy/jobs/utils.py
+++ b/src/lm_buddy/jobs/utils.py
@@ -1,0 +1,23 @@
+import functools
+import time
+
+from loguru import logger
+
+
+def timer(func):
+    """
+    Decorator which times the execution of the wrapped func.
+    Execution time is logged and also returned together with func's returned value
+    (output will be a tuple).
+    """
+
+    @functools.wraps(func)
+    def wrapper_timer(*args, **kwargs):
+        tic = time.perf_counter()
+        value = func(*args, **kwargs)
+        toc = time.perf_counter()
+        elapsed_time = toc - tic
+        logger.info(f"Elapsed time for {func.__name__}: {elapsed_time:0.4f} seconds")
+        return value, elapsed_time
+
+    return wrapper_timer

--- a/src/lm_buddy/paths.py
+++ b/src/lm_buddy/paths.py
@@ -14,6 +14,7 @@ class PathPrefix(str, Enum):
     HUGGINGFACE = "hf://"
     WANDB = "wandb://"
     S3 = "s3://"
+    OPENAI = "oai://"
 
 
 def strip_path_prefix(path: str) -> str:
@@ -52,6 +53,9 @@ def validate_asset_path(path: str) -> "AssetPath":
         # TODO: Validate the S3 path structure?
         # e.g. if the assumption is we always want a file or a dir, we could
         # use https://s3pathlib.readthedocs.io to verify (.is_file() or ._is_dir())
+        pass
+    elif path.startswith(PathPrefix.OPENAI):
+        # TODO: Validate the OAI path structure?
         pass
     else:
         allowed_prefixes = {x.value for x in PathPrefix}


### PR DESCRIPTION
## What's changing
Added a new `evaluate huggingface` entrypoint which supports evaluation of local and remote models (seq2seq, causal, openai, vllm, llamafile) and loading datasets / saving results on s3.

## How to test it
```
lm-buddy evaluate huggingface --config examples/configs/evaluation/hf_evaluate_config.yaml
```

## Related Jira Ticket
https://mzai.atlassian.net/browse/MZPLATFORM-78

## Additional notes for reviewers
I know we discussed messaging to mzai-platform's backend directly from lm-buddy jobs.
I am 100% in favor of it, I just wanted to keep this PR independent from messaging and I will create a new one to be tested together with the updated mzai-platform code.