### PR TITLE
Setuptools issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0,<=69.0"]
+requires = ["setuptools >= 61.0]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Current builds fail at integration tests.
The error is `ImportError: cannot import name 'packaging' from 'pkg_resources'` on different files.
Different projects have been [affected](https://github.com/pytorch/serve/issues/3176), and the suggested solution was to revert setuptools to a version < 70.0.0.
I tried that solution but got errors anyway. This PR reverts to the previous setuptools versions - with the hope the problem is soon fixed upstream.