### PR TITLE
Makes deps that require torch optional by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lm-buddy"
-version = "0.10.8"
+version = "0.11.0"
 authors = [
     { name = "Sean Friedowitz", email = "sean@mozilla.ai" },
     { name = "Aaron Gonzales", email = "aaron@mozilla.ai" },
@@ -16,22 +16,27 @@ description = "Ray-centric library for finetuning and evaluation of (large) lang
 readme = "README.md"
 license = { file = "LICENSE.md" }
 
-requires-python = ">=3.10,<3.11"
+requires-python = ">=3.10,<=3.12"
 
 dependencies = [
     # Core
-    "click==8.1.7",
-    "torch==2.1.2",
-    "scipy==1.10.1",
-    "wandb==0.16.3",
-    "protobuf==3.20.2",
+    "click>=8.1.7",
+    "scipy>=1.10.1",
+    "wandb>=0.16.3",
+    "protobuf>=3.20.2",
     "urllib3>=1.26.18,<2",
-    "pydantic==2.6.0",
-    "pydantic-yaml==1.2.0",
+    "pydantic>=2.6.0",
+    "pydantic-yaml>=1.2.0",
     "ray[default]==2.30.0",
     "loguru==0.7.2",
     "s3fs",
-    # HuggingFace
+]
+
+[project.optional-dependencies]
+ruff = ["ruff==0.2.1"]
+torchy = [
+    # HuggingFace / pytorch
+    "torch==2.3.1",
     "datasets>=2.17.1",
     "transformers==4.36.2",
     "accelerate==0.26.1",
@@ -42,17 +47,13 @@ dependencies = [
     # Evaluation frameworks
     "lm-eval==0.4.2",
     "einops==0.7.0",
-    "fschat==0.2.36",
     "openai==1.14.3",
     "ragas==0.1.5",
     "langchain-community==0.0.29",
     "langchain_openai==0.1.1",
     "sentencepiece==0.2.0",
-    "evaluate==0.4.2"
+    "evaluate==0.4.2",
 ]
-
-[project.optional-dependencies]
-ruff = ["ruff==0.2.1"]
 test = ["pytest==7.4.3", "pytest-cov==4.1.0"]
 docs = [
     "Sphinx==7.2.6",
@@ -61,7 +62,7 @@ docs = [
     "myst-parser==2.0.0",
     "furo==2024.1.29",
 ]
-dev = ["lm-buddy[ruff,test,docs]", "pre-commit==3.6.0", "jupyter==1.0.0"]
+dev = ["lm-buddy[torchy,ruff,test,docs]", "pre-commit==3.6.0", "jupyter==1.0.0"]
 
 [project.scripts]
 lm-buddy = "lm_buddy.cli:cli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 
 [project.optional-dependencies]
 ruff = ["ruff==0.2.1"]
-torchy = [
+jobs = [
     # HuggingFace / pytorch
     "torch==2.3.1",
     "datasets>=2.17.1",
@@ -64,7 +64,7 @@ docs = [
     "myst-parser==2.0.0",
     "furo==2024.1.29",
 ]
-dev = ["lm-buddy[torchy,ruff,test,docs]", "pre-commit==3.6.0", "jupyter==1.0.0"]
+dev = ["lm-buddy[jobs,ruff,test,docs]", "pre-commit==3.6.0", "jupyter==1.0.0"]
 
 [project.scripts]
 lm-buddy = "lm_buddy.cli:cli"

--- a/tests/integration/test_lm_harness.py
+++ b/tests/integration/test_lm_harness.py
@@ -9,7 +9,10 @@ from lm_buddy.paths import format_file_path
 
 @pytest.fixture
 def job_config(llm_model_path) -> LMHarnessJobConfig:
-    model_config = AutoModelConfig(path=format_file_path(llm_model_path))
+    # adding trust remote code to address issues in huggingface's env var
+    # https://github.com/EleutherAI/lm-evaluation-harness/pull/1998
+
+    model_config = AutoModelConfig(path=format_file_path(llm_model_path), trust_remote_code=True)
     tracking_config = WandbRunConfig(project="test-project")
     evaluation_config = LMHarnessEvaluationConfig(tasks=["hellaswag"], limit=5)
     return LMHarnessJobConfig(

--- a/tests/integration/test_lm_harness.py
+++ b/tests/integration/test_lm_harness.py
@@ -9,9 +9,6 @@ from lm_buddy.paths import format_file_path
 
 @pytest.fixture
 def job_config(llm_model_path) -> LMHarnessJobConfig:
-    # adding trust remote code to address issues in huggingface's env var
-    # https://github.com/EleutherAI/lm-evaluation-harness/pull/1998
-
     model_config = AutoModelConfig(path=format_file_path(llm_model_path))
     tracking_config = WandbRunConfig(project="test-project")
     evaluation_config = LMHarnessEvaluationConfig(tasks=["hellaswag"], limit=5)

--- a/tests/integration/test_lm_harness.py
+++ b/tests/integration/test_lm_harness.py
@@ -12,7 +12,7 @@ def job_config(llm_model_path) -> LMHarnessJobConfig:
     # adding trust remote code to address issues in huggingface's env var
     # https://github.com/EleutherAI/lm-evaluation-harness/pull/1998
 
-    model_config = AutoModelConfig(path=format_file_path(llm_model_path), trust_remote_code=True)
+    model_config = AutoModelConfig(path=format_file_path(llm_model_path))
     tracking_config = WandbRunConfig(project="test-project")
     evaluation_config = LMHarnessEvaluationConfig(tasks=["hellaswag"], limit=5)
     return LMHarnessJobConfig(


### PR DESCRIPTION
## What's changing
As discussed, this changes the dependency structure of this repo to make all packages that require Torch optional by default. This allows reuse of the configs more readily without other structural changes.


## How to test it
Tested internally by generating lockfiles on a project requiring this project with different  combos of [torchy, test, docs], verified pytorch is only in the ones in `torchy`.



