### PR TITLE
pins transitive dep of numpy version to <2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ requires-python = ">=3.11,<3.12"
 dependencies = [
     # Core
     "click>=8.1.7",
-    "scipy>=1.10.1",
+    "scipy==1.13.1",
+    "numpy<2.0.0",
     "wandb>=0.16.3",
     "protobuf>=3.20.2",
     "urllib3>=1.26.18,<2",


### PR DESCRIPTION
fixing this here for now; it's causing some annoyances elsewhere.