### PR TITLE
Mixed fixes + support for Mistral API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lm-buddy"
-version = "0.11.1"
+version = "0.12.0"
 authors = [
     { name = "Sean Friedowitz", email = "sean@mozilla.ai" },
     { name = "Aaron Gonzales", email = "aaron@mozilla.ai" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ jobs = [
     "langchain_openai==0.1.1",
     "sentencepiece==0.2.0",
     "evaluate==0.4.2",
+    "mistralai==0.4.2",
 ]
 test = ["pytest==7.4.3", "pytest-cov==4.1.0"]
 docs = [

--- a/src/lm_buddy/jobs/asset_loader.py
+++ b/src/lm_buddy/jobs/asset_loader.py
@@ -45,7 +45,9 @@ class HuggingFaceAssetLoader:
         The returned string has its `PathPrefix` stripped away..
         """
         raw_path = strip_path_prefix(path)
-        if path.startswith((PathPrefix.FILE, PathPrefix.HUGGINGFACE, PathPrefix.OPENAI)):
+        if path.startswith(
+            (PathPrefix.FILE, PathPrefix.HUGGINGFACE, PathPrefix.OPENAI, PathPrefix.MISTRAL)
+        ):
             return raw_path
         elif path.startswith(PathPrefix.WANDB):
             artifact = get_artifact_from_api(raw_path)

--- a/src/lm_buddy/jobs/asset_loader.py
+++ b/src/lm_buddy/jobs/asset_loader.py
@@ -97,7 +97,9 @@ class HuggingFaceModelLoader(HuggingFaceAssetLoader):
         An exception is raised if the HuggingFace repo does not contain a `config.json` file.
         """
         config_path = self.resolve_asset_path(config.path)
-        return AutoConfig.from_pretrained(pretrained_model_name_or_path=config_path)
+        return AutoConfig.from_pretrained(
+            pretrained_model_name_or_path=config_path, trust_remote_code=config.trust_remote_code
+        )
 
     def load_pretrained_model(
         self,

--- a/src/lm_buddy/jobs/evaluation/hf_evaluate.py
+++ b/src/lm_buddy/jobs/evaluation/hf_evaluate.py
@@ -91,7 +91,7 @@ def run_eval(config: HuggingFaceEvalJobConfig) -> Path:
 
     # Limit dataset length if max_samples is specified
     max_samples = config.evaluation.max_samples
-    if max_samples is not None and max_samples > 0:
+    if max_samples and max_samples > 0:
         if max_samples > len(dataset):
             logger.info(f"max_samples ({max_samples}) resized to dataset size ({len(dataset)})")
             max_samples = len(dataset)

--- a/src/lm_buddy/jobs/evaluation/hf_evaluate.py
+++ b/src/lm_buddy/jobs/evaluation/hf_evaluate.py
@@ -89,8 +89,12 @@ def run_eval(config: HuggingFaceEvalJobConfig) -> Path:
     dataset = hf_dataset_loader.load_dataset(config.dataset)
 
     # Limit dataset length if max_samples is specified
-    if config.evaluation.max_samples is not None:
-        dataset = dataset.select(range(config.evaluation.max_samples))
+    max_samples = config.evaluation.max_samples
+    if max_samples is not None and max_samples > 0:
+        if max_samples > len(dataset):
+            logger.info(f"max_samples ({max_samples}) resized to dataset size ({len(dataset)})")
+            max_samples = len(dataset)
+        dataset = dataset.select(range(max_samples))
 
     # Enable / disable tqdm
     input_samples = dataset["examples"]

--- a/src/lm_buddy/jobs/model_clients.py
+++ b/src/lm_buddy/jobs/model_clients.py
@@ -100,7 +100,7 @@ class APIModelClient(BaseModelClient):
         config: VLLMCompletionsConfig,
         client: OpenAI | MistralClient,
         prompt: str,
-        system: str = "You are a helpful assisant.",
+        system: str,
     ) -> Completion:
         """Connects to the API and returns a chat completion holding the model's response."""
         pass

--- a/src/lm_buddy/paths.py
+++ b/src/lm_buddy/paths.py
@@ -15,6 +15,7 @@ class PathPrefix(str, Enum):
     WANDB = "wandb://"
     S3 = "s3://"
     OPENAI = "oai://"
+    MISTRAL = "mistral://"
 
 
 def strip_path_prefix(path: str) -> str:
@@ -55,7 +56,10 @@ def validate_asset_path(path: str) -> "AssetPath":
         # use https://s3pathlib.readthedocs.io to verify (.is_file() or ._is_dir())
         pass
     elif path.startswith(PathPrefix.OPENAI):
-        # TODO: Validate the OAI path structure?
+        # TODO: Validate the OAI model name?
+        pass
+    elif path.startswith(PathPrefix.MISTRAL):
+        # TODO: Validate the mistral model name?
         pass
     else:
         allowed_prefixes = {x.value for x in PathPrefix}


### PR DESCRIPTION
Three main commits:
- added `allow_remote_code` to config => allows us to run Phi models
- fixed `max_samples` bug (now if the value is 0 all samples are considered, if it is larger than len(dataset) we get a warning and all the dataset is used)
- added support for Mistral API (created a general `APIModelClient` class and made OAI and Mistral as two subclasses as so much code was in common)
- bonus: added model name in output evals file :-)

Tested manually with different configs (seq2seq models locally, OAI, Mistral) and with pytest.

