### PR TITLE
Added model_max_length as a tok parameter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lm-buddy"
-version = "0.12.0"
+version = "0.12.1"
 authors = [
     { name = "Sean Friedowitz", email = "sean@mozilla.ai" },
     { name = "Aaron Gonzales", email = "aaron@mozilla.ai" },

--- a/src/lm_buddy/configs/huggingface.py
+++ b/src/lm_buddy/configs/huggingface.py
@@ -28,6 +28,7 @@ class AutoTokenizerConfig(LMBuddyConfig):
     path: AssetPath
     trust_remote_code: bool | None = None
     use_fast: bool | None = None
+    mod_max_length: int | None = None
 
 
 class DatasetConfig(LMBuddyConfig):

--- a/src/lm_buddy/jobs/asset_loader.py
+++ b/src/lm_buddy/jobs/asset_loader.py
@@ -163,6 +163,7 @@ class HuggingFaceTokenizerLoader(HuggingFaceAssetLoader):
             pretrained_model_name_or_path=tokenizer_path,
             trust_remote_code=config.trust_remote_code,
             use_fast=config.use_fast,
+            model_max_length=config.mod_max_length,
         )
         if tokenizer.pad_token_id is None:
             # Pad token required for generating consistent batch sizes

--- a/src/lm_buddy/jobs/evaluation/hf_evaluate.py
+++ b/src/lm_buddy/jobs/evaluation/hf_evaluate.py
@@ -120,7 +120,7 @@ def run_eval(config: HuggingFaceEvalJobConfig) -> Path:
         # for inference
         if config.evaluation.use_pipeline:
             logger.info(f"Using summarization pipeline. Model: {model_name}")
-            model_client = SummarizationPipelineModelClient(model_name, config.model)
+            model_client = SummarizationPipelineModelClient(model_name, config)
         else:
             logger.info(f"Using direct HF model invocation. Model: {model_name}")
             model_client = HuggingFaceModelClient(model_name, config)

--- a/src/lm_buddy/jobs/model_clients.py
+++ b/src/lm_buddy/jobs/model_clients.py
@@ -44,10 +44,16 @@ class SummarizationPipelineModelClient(BaseModelClient):
     (model is loaded locally).
     """
 
-    def __init__(self, model: str, config: AutoModelConfig):
+    def __init__(self, model: str, config: HuggingFaceEvalJobConfig):
+        self._config = config
+
+        hf_tokenizer_loader = HuggingFaceTokenizerLoader()
+        self._tokenizer = hf_tokenizer_loader.load_pretrained_tokenizer(config.tokenizer)
+
         self._summarizer = pipeline(
             "summarization",
             model=model,
+            tokenizer=self._tokenizer,
             device=0 if torch.cuda.is_available() else -1,
             truncation=True,
         )

--- a/src/lm_buddy/jobs/model_clients.py
+++ b/src/lm_buddy/jobs/model_clients.py
@@ -9,7 +9,6 @@ from openai.types import Completion
 from transformers import pipeline
 
 from lm_buddy.configs.common import LMBuddyConfig
-from lm_buddy.configs.huggingface import AutoModelConfig
 from lm_buddy.configs.jobs.hf_evaluate import HuggingFaceEvalJobConfig
 from lm_buddy.configs.vllm import VLLMCompletionsConfig
 from lm_buddy.jobs.asset_loader import HuggingFaceModelLoader, HuggingFaceTokenizerLoader


### PR DESCRIPTION
Since 4.40.0, transformers does not get model_max_tokens from the model's family dict but explicitly looks for this parameter in `tokenizer_config.json`. Not all models provide this, so one possibility is to explicitly allow users to provide this parameter in the config. This PR implements exactly this.

Tested with facebook/bart-large-cnn + pytest unit/integration tests.