### PR TITLE
Update Ray job submission example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ runtime_env = {
 
 # Assuming 'config.yaml' is present in the working directory
 client.submit_job(
-    entrypoint="lm_buddy run <job-name> --config config.yaml", 
+    entrypoint="lm_buddy finetune <job-name> --config config.yaml", 
     runtime_env=runtime_env,
     entrypoint_num_gpus=1
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lm-buddy"
-version = "0.13.0"
+version = "0.14.0"
 authors = [
     { name = "Sean Friedowitz", email = "sean@mozilla.ai" },
     { name = "Aaron Gonzales", email = "aaron@mozilla.ai" },


### PR DESCRIPTION
Commit 0975fb2 changes the CLI groups `finetune` and `evaluate`, but the Ray job submission example in the README file still uses the deprecated `run` command.

## What's changing

Update the example to match the new API.

## How to test it

Run the example script on a Ray cluster.
