### PR TITLE
Notice of archive of repo 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
 # LM Buddy
 
-> [!WARNING]
+> [!IMPORTANT]
 >
-> LM Buddy is in the early stages of development.
-> It is missing important features and documentation.
-> You should expect breaking changes in the core interfaces and configuration structures
-> as development continues.
-> Use only if you are comfortable working in this environment.
+> The lm-buddy repo is being archived and its functionality is being folded into [Lumigator](https://github.com/mozilla-ai/lumigator).
+> For more on the context and decisions behind this, [please read here.](https://github.com/mozilla-ai/lumigator/pull/209)
 
 LM Buddy is a collection of jobs for finetuning and evaluating open-source (large) language models.
 The library makes use of YAML-based configuration files as inputs to CLI commands for each job,


### PR DESCRIPTION
## What's changing
 lm-buddy is [being folded into Lumigator](https://github.com/mozilla-ai/lumigator/pull/209). We'd like to make sure people understand the change before we archive the repo. 

## How to test it

## Related Jira Ticket

## Additional notes for reviewers

