### PR TITLE
Final version bump for pip deprecation notice

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lm-buddy"
-version = "0.14.0"
+version = "0.15.0"
 authors = [
     { name = "Sean Friedowitz", email = "sean@mozilla.ai" },
     { name = "Aaron Gonzales", email = "aaron@mozilla.ai" },


### PR DESCRIPTION
## What's changing

We want to bump the version so that the [README on pip](https://pypi.org/project/lm-buddy/) notifies people this project is being deprecated and ported to Lumigator. 

## How to test it

## Related Jira Ticket

## Additional notes for reviewers

